### PR TITLE
Feature: Entity type ID shorthand

### DIFF
--- a/Examples/invite_beta_tester/InviteBetaTester.swift
+++ b/Examples/invite_beta_tester/InviteBetaTester.swift
@@ -29,7 +29,6 @@ import Utilities
                 Resources.v1.betaTesters.post(
                     .init(
                         data: .init(
-                            type: .betaTesters,
                             attributes: .init(
                                 firstName: firstName,
                                 lastName: lastName,
@@ -51,20 +50,9 @@ import Utilities
                     Resources.v1.betaTesterInvitations.post(
                         .init(
                             data: .init(
-                                type: .betaTesterInvitations,
                                 relationships: .init(
-                                    betaTester: .init(
-                                        data: .init(
-                                            type: .betaTesters,
-                                            id: tester.id
-                                        )
-                                    ),
-                                    app: .init(
-                                        data: .init(
-                                            type: .apps,
-                                            id: app.id
-                                        )
-                                    )
+                                    betaTester: .init(data: .init(id: tester.id)),
+                                    app: .init(data: .init(id: app.id))
                                 )
                             )
                         )

--- a/Examples/invite_user/InviteUser.swift
+++ b/Examples/invite_user/InviteUser.swift
@@ -31,7 +31,6 @@ import Utilities
             Resources.v1.userInvitations.post(
                 .init(
                     data: .init(
-                        type: .userInvitations,
                         attributes: .init(
                             email: email,
                             firstName: firstName,

--- a/Examples/register_device/RegisterDevice.swift
+++ b/Examples/register_device/RegisterDevice.swift
@@ -19,7 +19,6 @@ import Utilities
             Resources.v1.devices.post(
                 .init(
                     data: .init(
-                        type: .devices,
                         attributes: .init(
                             name: name,
                             platform: platform,

--- a/Examples/upload_preview/UploadPreview.swift
+++ b/Examples/upload_preview/UploadPreview.swift
@@ -61,11 +61,8 @@ import Utilities
                 Resources.v1.appStoreVersionLocalizations.post(
                     .init(
                         data: .init(
-                            type: .appStoreVersionLocalizations,
                             attributes: .init(locale: locale),
-                            relationships: .init(
-                                appStoreVersion: .init(data: .init(type: .appStoreVersions, id: version.id))
-                            )
+                            relationships: .init(appStoreVersion: .init(data: .init(id: version.id)))
                         )
                     )
                 )
@@ -89,13 +86,8 @@ import Utilities
                     Resources.v1.appPreviewSets.post(
                         .init(
                             data: .init(
-                                type: .appPreviewSets,
                                 attributes: .init(previewType: previewType),
-                                relationships: .init(
-                                    appStoreVersionLocalization: .init(
-                                        data: .init(type: .appStoreVersionLocalizations, id: localization.id)
-                                    )
-                                )
+                                relationships: .init(appStoreVersionLocalization: .init(data: .init(id: localization.id)))
                             )
                         )
                     )
@@ -111,14 +103,11 @@ import Utilities
                         Resources.v1.appPreviews.post(
                             .init(
                                 data: .init(
-                                    type: .appPreviews,
                                     attributes: .init(
                                         fileSize: previewFile.count,
                                         fileName: previewFileURL.lastPathComponent
                                     ),
-                                    relationships: .init(
-                                        appPreviewSet: .init(data: .init(type: .appPreviewSets, id: previewSet.id))
-                                    )
+                                    relationships: .init(appPreviewSet: .init(data: .init(id: previewSet.id)))
                                 )
                             )
                         )
@@ -146,7 +135,6 @@ import Utilities
                         .patch(
                             .init(
                                 data: .init(
-                                    type: .appPreviews,
                                     id: preview.id,
                                     attributes: .init(sourceFileChecksum: previewFileChecksum, isUploaded: true)
                                 )

--- a/Examples/upload_preview/UploadPreview.swift
+++ b/Examples/upload_preview/UploadPreview.swift
@@ -87,7 +87,9 @@ import Utilities
                         .init(
                             data: .init(
                                 attributes: .init(previewType: previewType),
-                                relationships: .init(appStoreVersionLocalization: .init(data: .init(id: localization.id)))
+                                relationships: .init(
+                                    appStoreVersionLocalization: .init(data: .init(id: localization.id))
+                                )
                             )
                         )
                     )

--- a/Examples/upload_screenshot/UploadScreenshot.swift
+++ b/Examples/upload_screenshot/UploadScreenshot.swift
@@ -89,7 +89,9 @@ import Utilities
                         .init(
                             data: .init(
                                 attributes: .init(screenshotDisplayType: screenshotType),
-                                relationships: .init(appStoreVersionLocalization: .init(data: .init(id: localization.id)))
+                                relationships: .init(
+                                    appStoreVersionLocalization: .init(data: .init(id: localization.id))
+                                )
                             )
                         )
                     )

--- a/Examples/upload_screenshot/UploadScreenshot.swift
+++ b/Examples/upload_screenshot/UploadScreenshot.swift
@@ -61,11 +61,8 @@ import Utilities
                 Resources.v1.appStoreVersionLocalizations.post(
                     .init(
                         data: .init(
-                            type: .appStoreVersionLocalizations,
                             attributes: .init(locale: locale),
-                            relationships: .init(
-                                appStoreVersion: .init(data: .init(type: .appStoreVersions, id: version.id))
-                            )
+                            relationships: .init(appStoreVersion: .init(data: .init(id: version.id)))
                         )
                     )
                 )
@@ -91,13 +88,8 @@ import Utilities
                     Resources.v1.appScreenshotSets.post(
                         .init(
                             data: .init(
-                                type: .appScreenshotSets,
                                 attributes: .init(screenshotDisplayType: screenshotType),
-                                relationships: .init(
-                                    appStoreVersionLocalization: .init(
-                                        data: .init(type: .appStoreVersionLocalizations, id: localization.id)
-                                    )
-                                )
+                                relationships: .init(appStoreVersionLocalization: .init(data: .init(id: localization.id)))
                             )
                         )
                     )
@@ -113,16 +105,11 @@ import Utilities
                         Resources.v1.appScreenshots.post(
                             .init(
                                 data: .init(
-                                    type: .appScreenshots,
                                     attributes: .init(
                                         fileSize: screenshotFile.count,
                                         fileName: screenshotFileURL.lastPathComponent
                                     ),
-                                    relationships: .init(
-                                        appScreenshotSet: .init(
-                                            data: .init(type: .appScreenshotSets, id: screenshotSet.id)
-                                        )
-                                    )
+                                    relationships: .init(appScreenshotSet: .init(data: .init(id: screenshotSet.id)))
                                 )
                             )
                         )
@@ -150,7 +137,6 @@ import Utilities
                         .patch(
                             .init(
                                 data: .init(
-                                    type: .appScreenshots,
                                     id: screenshot.id,
                                     attributes: .init(sourceFileChecksum: screenshotFileChecksum, isUploaded: true)
                                 )

--- a/Package.swift
+++ b/Package.swift
@@ -47,8 +47,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "create-api",
-            url: "https://github.com/CreateAPI/CreateAPI/releases/download/0.2.0/create-api.artifactbundle.zip",
-            checksum: "6f8a3ce099f07eb2655ccaf6f66d8c9a09b74bb2307781c4adec36609ddac009"
+            url: "https://github.com/aaronsky/CreateAPI/releases/download/0.2.0-alpha.1/create-api.artifactbundle.zip",
+            checksum: "e4e128b2080247802a654bec1aba2c3c161e7ab3f407ea8f02f3474cea772792"
         ),
         .plugin(
             name: "CreateAPI",

--- a/Sources/AppStoreConnect/AppStoreConnect.docc/Articles/UploadingFiles.md
+++ b/Sources/AppStoreConnect/AppStoreConnect.docc/Articles/UploadingFiles.md
@@ -35,19 +35,11 @@ let reserveScreenshot = try await client.send(
     Resources.v1.appScreenshots.post(
         .init(
             data: .init(
-                type: .appScreenshots,
                 attributes: .init(
                     fileSize: screenshotData.count,
                     fileName: basename
                 ),
-                relationships: .init(
-                    appScreenshotSet: .init(
-                        data: .init(
-                            type: .appScreenshotSets,
-                            id: screenshotSet.data.id
-                        )
-                    )
-                )
+                relationships: .init(appScreenshotSet: .init(data: .init(id: screenshotSet.data.id)))
             )
         )
     )
@@ -71,7 +63,6 @@ let committedScreenshot = try await client.send(
     Resources.v1.appScreenshots.id(reserveScreenshot.data.id).patch(
         .init(
             data: .init(
-                type: .appScreenshots, 
                 id: reserveScreenshot.data.id, 
                 attributes: .init(
                     sourceFileChecksum: checksum, 

--- a/Sources/AppStoreConnect/Networking/Request.swift
+++ b/Sources/AppStoreConnect/Networking/Request.swift
@@ -130,7 +130,7 @@ extension Request {
         query: [(String, String?)]? = nil,
         headers: [String: String]? = nil
     ) -> Request {
-        .init(path: path, method: "GET", baseURL: baseURL, query: query, headers: headers)
+        .init(path: path, baseURL: baseURL, method: "GET", query: query, headers: headers)
     }
 
     /// Construct a "POST" request.
@@ -149,7 +149,7 @@ extension Request {
         body: Encodable? = nil,
         headers: [String: String]? = nil
     ) -> Request {
-        .init(path: path, method: "POST", baseURL: baseURL, query: query, body: body, headers: headers)
+        .init(path: path, baseURL: baseURL, method: "POST", query: query, body: body, headers: headers)
     }
 
     /// Construct a "PUT" request.
@@ -168,7 +168,7 @@ extension Request {
         body: (any Encodable)? = nil,
         headers: [String: String]? = nil
     ) -> Request {
-        .init(path: path, method: "PUT", baseURL: baseURL, query: query, body: body, headers: headers)
+        .init(path: path, baseURL: baseURL, method: "PUT", query: query, body: body, headers: headers)
     }
 
     /// Construct a "PATCH" request.
@@ -187,7 +187,7 @@ extension Request {
         body: (any Encodable)? = nil,
         headers: [String: String]? = nil
     ) -> Request {
-        .init(path: path, method: "PATCH", baseURL: baseURL, query: query, body: body, headers: headers)
+        .init(path: path, baseURL: baseURL, method: "PATCH", query: query, body: body, headers: headers)
     }
 
     /// Construct a "DELETE" request.
@@ -206,7 +206,7 @@ extension Request {
         body: (any Encodable)? = nil,
         headers: [String: String]? = nil
     ) -> Request {
-        .init(path: path, method: "DELETE", baseURL: baseURL, query: query, body: body, headers: headers)
+        .init(path: path, baseURL: baseURL, method: "DELETE", query: query, body: body, headers: headers)
     }
 
     /// Construct a "OPTIONS" request.
@@ -223,7 +223,7 @@ extension Request {
         query: [(String, String?)]? = nil,
         headers: [String: String]? = nil
     ) -> Request {
-        .init(path: path, method: "OPTIONS", baseURL: baseURL, query: query, headers: headers)
+        .init(path: path, baseURL: baseURL, method: "OPTIONS", query: query, headers: headers)
     }
 
     /// Construct a "HEAD" request.
@@ -240,7 +240,7 @@ extension Request {
         query: [(String, String?)]? = nil,
         headers: [String: String]? = nil
     ) -> Request {
-        .init(path: path, method: "HEAD", baseURL: baseURL, query: query, headers: headers)
+        .init(path: path, baseURL: baseURL, method: "HEAD", query: query, headers: headers)
     }
 
     /// Construct a "TRACE" request.
@@ -257,7 +257,7 @@ extension Request {
         query: [(String, String?)]? = nil,
         headers: [String: String]? = nil
     ) -> Request {
-        .init(path: path, method: "TRACE", baseURL: baseURL, query: query, headers: headers)
+        .init(path: path, baseURL: baseURL, method: "TRACE", query: query, headers: headers)
     }
 }
 
@@ -274,7 +274,7 @@ extension Request {
         query: [(String, String?)]? = nil,
         headers: [String: String]? = nil
     ) -> Request {
-        .init(path: "", method: "GET", baseURL: url, query: query, headers: headers)
+        .init(path: "", baseURL: url, method: "GET", query: query, headers: headers)
     }
 
     /// Construct a "POST" request.
@@ -291,7 +291,7 @@ extension Request {
         body: Encodable? = nil,
         headers: [String: String]? = nil
     ) -> Request {
-        .init(path: "", method: "POST", baseURL: url, query: query, body: body, headers: headers)
+        .init(path: "", baseURL: url, method: "POST", query: query, body: body, headers: headers)
     }
 
     /// Construct a "PUT" request.
@@ -308,7 +308,7 @@ extension Request {
         body: (any Encodable)? = nil,
         headers: [String: String]? = nil
     ) -> Request {
-        .init(path: "", method: "PUT", baseURL: url, query: query, body: body, headers: headers)
+        .init(path: "", baseURL: url, method: "PUT", query: query, body: body, headers: headers)
     }
 
     /// Construct a "PATCH" request.
@@ -325,7 +325,7 @@ extension Request {
         body: (any Encodable)? = nil,
         headers: [String: String]? = nil
     ) -> Request {
-        .init(path: "", method: "PATCH", baseURL: url, query: query, body: body, headers: headers)
+        .init(path: "", baseURL: url, method: "PATCH", query: query, body: body, headers: headers)
     }
 
     /// Construct a "DELETE" request.
@@ -342,7 +342,7 @@ extension Request {
         body: (any Encodable)? = nil,
         headers: [String: String]? = nil
     ) -> Request {
-        .init(path: "", method: "DELETE", baseURL: url, query: query, body: body, headers: headers)
+        .init(path: "", baseURL: url, method: "DELETE", query: query, body: body, headers: headers)
     }
 
     /// Construct a "OPTIONS" request.
@@ -357,7 +357,7 @@ extension Request {
         query: [(String, String?)]? = nil,
         headers: [String: String]? = nil
     ) -> Request {
-        .init(path: "", method: "OPTIONS", baseURL: url, query: query, headers: headers)
+        .init(path: "", baseURL: url, method: "OPTIONS", query: query, headers: headers)
     }
 
     /// Construct a "HEAD" request.
@@ -372,7 +372,7 @@ extension Request {
         query: [(String, String?)]? = nil,
         headers: [String: String]? = nil
     ) -> Request {
-        .init(path: "", method: "HEAD", baseURL: url, query: query, headers: headers)
+        .init(path: "", baseURL: url, method: "HEAD", query: query, headers: headers)
     }
 
     /// Construct a "TRACE" request.
@@ -387,6 +387,6 @@ extension Request {
         query: [(String, String?)]? = nil,
         headers: [String: String]? = nil
     ) -> Request {
-        .init(path: "", method: "TRACE", baseURL: url, query: query, headers: headers)
+        .init(path: "", baseURL: url, method: "TRACE", query: query, headers: headers)
     }
 }

--- a/Sources/_Specification/.create-api.yml
+++ b/Sources/_Specification/.create-api.yml
@@ -18,6 +18,8 @@ dataTypes:
     uri-reference: URL
 
 entities:
+  alwaysIncludeDecodableImplementation: false
+  alwaysIncludeEncodableImplementation: false
   includeIdentifiableConformance: true
   includeInitializer: true
   optimizeCodingKeys: false

--- a/Sources/_Specification/Generated/Entities/Actor.swift
+++ b/Sources/_Specification/Generated/Entities/Actor.swift
@@ -46,7 +46,7 @@ public struct Actor: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .actors, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AgeRatingDeclaration.swift
+++ b/Sources/_Specification/Generated/Entities/AgeRatingDeclaration.swift
@@ -156,7 +156,7 @@ public struct AgeRatingDeclaration: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .ageRatingDeclarations, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AgeRatingDeclarationUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AgeRatingDeclarationUpdateRequest.swift
@@ -158,7 +158,7 @@ public struct AgeRatingDeclarationUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .ageRatingDeclarations, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AlternativeDistributionKey.swift
+++ b/Sources/_Specification/Generated/Entities/AlternativeDistributionKey.swift
@@ -23,7 +23,7 @@ public struct AlternativeDistributionKey: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .alternativeDistributionKeys, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AlternativeDistributionKeyCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AlternativeDistributionKeyCreateRequest.swift
@@ -39,7 +39,7 @@ public struct AlternativeDistributionKeyCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -55,7 +55,7 @@ public struct AlternativeDistributionKeyCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .alternativeDistributionKeys, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AlternativeDistributionPackage.swift
+++ b/Sources/_Specification/Generated/Entities/AlternativeDistributionPackage.swift
@@ -46,7 +46,7 @@ public struct AlternativeDistributionPackage: Codable, Equatable, Identifiable {
                     case alternativeDistributionPackageVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .alternativeDistributionPackageVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -64,7 +64,7 @@ public struct AlternativeDistributionPackage: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .alternativeDistributionPackages, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AlternativeDistributionPackageCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AlternativeDistributionPackageCreateRequest.swift
@@ -30,7 +30,7 @@ public struct AlternativeDistributionPackageCreateRequest: Codable, Equatable {
                         case appStoreVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -46,7 +46,7 @@ public struct AlternativeDistributionPackageCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .alternativeDistributionPackages, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/AlternativeDistributionPackageDelta.swift
+++ b/Sources/_Specification/Generated/Entities/AlternativeDistributionPackageDelta.swift
@@ -29,7 +29,7 @@ public struct AlternativeDistributionPackageDelta: Codable, Equatable, Identifia
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .alternativeDistributionPackageDeltas, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AlternativeDistributionPackageVariant.swift
+++ b/Sources/_Specification/Generated/Entities/AlternativeDistributionPackageVariant.swift
@@ -29,7 +29,7 @@ public struct AlternativeDistributionPackageVariant: Codable, Equatable, Identif
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .alternativeDistributionPackageVariants, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AlternativeDistributionPackageVersion.swift
+++ b/Sources/_Specification/Generated/Entities/AlternativeDistributionPackageVersion.swift
@@ -70,7 +70,7 @@ public struct AlternativeDistributionPackageVersion: Codable, Equatable, Identif
                     case alternativeDistributionPackageVariants
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .alternativeDistributionPackageVariants, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -111,7 +111,7 @@ public struct AlternativeDistributionPackageVersion: Codable, Equatable, Identif
                     case alternativeDistributionPackageDeltas
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .alternativeDistributionPackageDeltas, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -151,7 +151,7 @@ public struct AlternativeDistributionPackageVersion: Codable, Equatable, Identif
                     case alternativeDistributionPackages
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .alternativeDistributionPackages, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -170,7 +170,7 @@ public struct AlternativeDistributionPackageVersion: Codable, Equatable, Identif
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .alternativeDistributionPackageVersions, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AnalyticsReport.swift
+++ b/Sources/_Specification/Generated/Entities/AnalyticsReport.swift
@@ -33,7 +33,7 @@ public struct AnalyticsReport: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .analyticsReports, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AnalyticsReportInstance.swift
+++ b/Sources/_Specification/Generated/Entities/AnalyticsReportInstance.swift
@@ -31,7 +31,7 @@ public struct AnalyticsReportInstance: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .analyticsReportInstances, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AnalyticsReportRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AnalyticsReportRequest.swift
@@ -67,7 +67,7 @@ public struct AnalyticsReportRequest: Codable, Equatable, Identifiable {
                     case analyticsReports
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .analyticsReports, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -85,7 +85,7 @@ public struct AnalyticsReportRequest: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .analyticsReportRequests, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AnalyticsReportRequestCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AnalyticsReportRequestCreateRequest.swift
@@ -44,7 +44,7 @@ public struct AnalyticsReportRequestCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -60,7 +60,7 @@ public struct AnalyticsReportRequestCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .analyticsReportRequests, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AnalyticsReportSegment.swift
+++ b/Sources/_Specification/Generated/Entities/AnalyticsReportSegment.swift
@@ -27,7 +27,7 @@ public struct AnalyticsReportSegment: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .analyticsReportSegments, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/App.swift
+++ b/Sources/_Specification/Generated/Entities/App.swift
@@ -119,7 +119,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case appEncryptionDeclarations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appEncryptionDeclarations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -159,7 +159,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case ciProducts
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .ciProducts, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -199,7 +199,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case betaGroups
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .betaGroups, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -240,7 +240,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case appStoreVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -281,7 +281,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case preReleaseVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .preReleaseVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -322,7 +322,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case betaAppLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .betaAppLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -363,7 +363,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case builds
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .builds, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -403,7 +403,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case betaLicenseAgreements
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .betaLicenseAgreements, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -442,7 +442,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case betaAppReviewDetails
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .betaAppReviewDetails, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -482,7 +482,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case appInfos
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appInfos, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -523,7 +523,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case appClips
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appClips, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -563,7 +563,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case endUserLicenseAgreements
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .endUserLicenseAgreements, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -602,7 +602,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case appPreOrders
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appPreOrders, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -642,7 +642,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case appPrices
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appPrices, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -683,7 +683,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -724,7 +724,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case inAppPurchases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -765,7 +765,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case subscriptionGroups
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionGroups, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -806,7 +806,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case gameCenterEnabledVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterEnabledVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -847,7 +847,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case appCustomProductPages
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCustomProductPages, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -888,7 +888,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case inAppPurchases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -929,7 +929,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case promotedPurchases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .promotedPurchases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -970,7 +970,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case appEvents
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appEvents, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -1011,7 +1011,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case reviewSubmissions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .reviewSubmissions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -1051,7 +1051,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case subscriptionGracePeriods
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionGracePeriods, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -1090,7 +1090,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case gameCenterDetails
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterDetails, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -1130,7 +1130,7 @@ public struct App: Codable, Equatable, Identifiable {
                     case appStoreVersionExperiments
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionExperiments, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -1173,7 +1173,7 @@ public struct App: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .apps, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppAvailability.swift
+++ b/Sources/_Specification/Generated/Entities/AppAvailability.swift
@@ -59,7 +59,7 @@ public struct AppAvailability: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -99,7 +99,7 @@ public struct AppAvailability: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -118,7 +118,7 @@ public struct AppAvailability: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appAvailabilities, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppAvailabilityCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppAvailabilityCreateRequest.swift
@@ -44,7 +44,7 @@ public struct AppAvailabilityCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -66,7 +66,7 @@ public struct AppAvailabilityCreateRequest: Codable, Equatable {
                         case territories
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .territories, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -83,7 +83,7 @@ public struct AppAvailabilityCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appAvailabilities, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppAvailabilityV2.swift
+++ b/Sources/_Specification/Generated/Entities/AppAvailabilityV2.swift
@@ -59,7 +59,7 @@ public struct AppAvailabilityV2: Codable, Equatable, Identifiable {
                     case territoryAvailabilities
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territoryAvailabilities, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -77,7 +77,7 @@ public struct AppAvailabilityV2: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appAvailabilities, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppAvailabilityV2CreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppAvailabilityV2CreateRequest.swift
@@ -45,7 +45,7 @@ public struct AppAvailabilityV2CreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -67,7 +67,7 @@ public struct AppAvailabilityV2CreateRequest: Codable, Equatable {
                         case territoryAvailabilities
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .territoryAvailabilities, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -84,7 +84,7 @@ public struct AppAvailabilityV2CreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appAvailabilities, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppBetaTestersLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppBetaTestersLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct AppBetaTestersLinkagesRequest: Codable, Equatable {
             case betaTesters
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .betaTesters, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/AppCategory.swift
+++ b/Sources/_Specification/Generated/Entities/AppCategory.swift
@@ -56,7 +56,7 @@ public struct AppCategory: Codable, Equatable, Identifiable {
                     case appCategories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCategories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -96,7 +96,7 @@ public struct AppCategory: Codable, Equatable, Identifiable {
                     case appCategories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCategories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -114,7 +114,7 @@ public struct AppCategory: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appCategories, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppClip.swift
+++ b/Sources/_Specification/Generated/Entities/AppClip.swift
@@ -59,7 +59,7 @@ public struct AppClip: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -99,7 +99,7 @@ public struct AppClip: Codable, Equatable, Identifiable {
                     case appClipDefaultExperiences
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appClipDefaultExperiences, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -118,7 +118,7 @@ public struct AppClip: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appClips, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppClipAdvancedExperience.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipAdvancedExperience.swift
@@ -246,7 +246,7 @@ public struct AppClipAdvancedExperience: Codable, Equatable, Identifiable {
                     case appClips
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appClips, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -285,7 +285,7 @@ public struct AppClipAdvancedExperience: Codable, Equatable, Identifiable {
                     case appClipAdvancedExperienceImages
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appClipAdvancedExperienceImages, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -325,7 +325,7 @@ public struct AppClipAdvancedExperience: Codable, Equatable, Identifiable {
                     case appClipAdvancedExperienceLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appClipAdvancedExperienceLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -345,7 +345,7 @@ public struct AppClipAdvancedExperience: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appClipAdvancedExperiences, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppClipAdvancedExperienceCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipAdvancedExperienceCreateRequest.swift
@@ -214,7 +214,7 @@ public struct AppClipAdvancedExperienceCreateRequest: Codable, Equatable {
                         case appClips
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appClips, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -236,7 +236,7 @@ public struct AppClipAdvancedExperienceCreateRequest: Codable, Equatable {
                         case appClipAdvancedExperienceImages
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appClipAdvancedExperienceImages, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -258,7 +258,7 @@ public struct AppClipAdvancedExperienceCreateRequest: Codable, Equatable {
                         case appClipAdvancedExperienceLocalizations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appClipAdvancedExperienceLocalizations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -276,7 +276,7 @@ public struct AppClipAdvancedExperienceCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appClipAdvancedExperiences, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppClipAdvancedExperienceImage.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipAdvancedExperienceImage.swift
@@ -33,7 +33,7 @@ public struct AppClipAdvancedExperienceImage: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appClipAdvancedExperienceImages, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppClipAdvancedExperienceImageCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipAdvancedExperienceImageCreateRequest.swift
@@ -26,7 +26,7 @@ public struct AppClipAdvancedExperienceImageCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes) {
+        public init(type: `Type` = .appClipAdvancedExperienceImages, attributes: Attributes) {
             self.type = type
             self.attributes = attributes
         }

--- a/Sources/_Specification/Generated/Entities/AppClipAdvancedExperienceImageUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipAdvancedExperienceImageUpdateRequest.swift
@@ -32,7 +32,7 @@ public struct AppClipAdvancedExperienceImageUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appClipAdvancedExperienceImages, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppClipAdvancedExperienceLocalization.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipAdvancedExperienceLocalization.swift
@@ -27,7 +27,7 @@ public struct AppClipAdvancedExperienceLocalization: Codable, Equatable, Identif
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appClipAdvancedExperienceLocalizations, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppClipAdvancedExperienceLocalizationInlineCreate.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipAdvancedExperienceLocalizationInlineCreate.swift
@@ -26,7 +26,7 @@ public struct AppClipAdvancedExperienceLocalizationInlineCreate: Codable, Equata
         }
     }
 
-    public init(type: `Type`, id: String? = nil, attributes: Attributes? = nil) {
+    public init(type: `Type` = .appClipAdvancedExperienceLocalizations, id: String? = nil, attributes: Attributes? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppClipAdvancedExperienceUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipAdvancedExperienceUpdateRequest.swift
@@ -224,7 +224,7 @@ public struct AppClipAdvancedExperienceUpdateRequest: Codable, Equatable {
                         case appClips
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appClips, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -246,7 +246,7 @@ public struct AppClipAdvancedExperienceUpdateRequest: Codable, Equatable {
                         case appClipAdvancedExperienceImages
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appClipAdvancedExperienceImages, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -268,7 +268,7 @@ public struct AppClipAdvancedExperienceUpdateRequest: Codable, Equatable {
                         case appClipAdvancedExperienceLocalizations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appClipAdvancedExperienceLocalizations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -286,7 +286,7 @@ public struct AppClipAdvancedExperienceUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
+        public init(type: `Type` = .appClipAdvancedExperiences, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppClipAppStoreReviewDetail.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipAppStoreReviewDetail.swift
@@ -58,7 +58,7 @@ public struct AppClipAppStoreReviewDetail: Codable, Equatable, Identifiable {
                     case appClipDefaultExperiences
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appClipDefaultExperiences, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -75,7 +75,7 @@ public struct AppClipAppStoreReviewDetail: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appClipAppStoreReviewDetails, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppClipAppStoreReviewDetailCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipAppStoreReviewDetailCreateRequest.swift
@@ -43,7 +43,7 @@ public struct AppClipAppStoreReviewDetailCreateRequest: Codable, Equatable {
                         case appClipDefaultExperiences
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appClipDefaultExperiences, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -59,7 +59,7 @@ public struct AppClipAppStoreReviewDetailCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes? = nil, relationships: Relationships) {
+        public init(type: `Type` = .appClipAppStoreReviewDetails, attributes: Attributes? = nil, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppClipAppStoreReviewDetailUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipAppStoreReviewDetailUpdateRequest.swift
@@ -29,7 +29,7 @@ public struct AppClipAppStoreReviewDetailUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appClipAppStoreReviewDetails, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppClipDefaultExperience.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipDefaultExperience.swift
@@ -57,7 +57,7 @@ public struct AppClipDefaultExperience: Codable, Equatable, Identifiable {
                     case appClips
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appClips, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -96,7 +96,7 @@ public struct AppClipDefaultExperience: Codable, Equatable, Identifiable {
                     case appStoreVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -136,7 +136,7 @@ public struct AppClipDefaultExperience: Codable, Equatable, Identifiable {
                     case appClipDefaultExperienceLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appClipDefaultExperienceLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -176,7 +176,7 @@ public struct AppClipDefaultExperience: Codable, Equatable, Identifiable {
                     case appClipAppStoreReviewDetails
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appClipAppStoreReviewDetails, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -196,7 +196,7 @@ public struct AppClipDefaultExperience: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appClipDefaultExperiences, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppClipDefaultExperienceCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipDefaultExperienceCreateRequest.swift
@@ -41,7 +41,7 @@ public struct AppClipDefaultExperienceCreateRequest: Codable, Equatable {
                         case appClips
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appClips, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -63,7 +63,7 @@ public struct AppClipDefaultExperienceCreateRequest: Codable, Equatable {
                         case appStoreVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -85,7 +85,7 @@ public struct AppClipDefaultExperienceCreateRequest: Codable, Equatable {
                         case appClipDefaultExperiences
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appClipDefaultExperiences, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -103,7 +103,7 @@ public struct AppClipDefaultExperienceCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes? = nil, relationships: Relationships) {
+        public init(type: `Type` = .appClipDefaultExperiences, attributes: Attributes? = nil, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppClipDefaultExperienceLocalization.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipDefaultExperienceLocalization.swift
@@ -57,7 +57,7 @@ public struct AppClipDefaultExperienceLocalization: Codable, Equatable, Identifi
                     case appClipDefaultExperiences
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appClipDefaultExperiences, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -96,7 +96,7 @@ public struct AppClipDefaultExperienceLocalization: Codable, Equatable, Identifi
                     case appClipHeaderImages
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appClipHeaderImages, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -114,7 +114,7 @@ public struct AppClipDefaultExperienceLocalization: Codable, Equatable, Identifi
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appClipDefaultExperienceLocalizations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppClipDefaultExperienceLocalizationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipDefaultExperienceLocalizationCreateRequest.swift
@@ -41,7 +41,7 @@ public struct AppClipDefaultExperienceLocalizationCreateRequest: Codable, Equata
                         case appClipDefaultExperiences
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appClipDefaultExperiences, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct AppClipDefaultExperienceLocalizationCreateRequest: Codable, Equata
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appClipDefaultExperienceLocalizations, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppClipDefaultExperienceLocalizationUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipDefaultExperienceLocalizationUpdateRequest.swift
@@ -25,7 +25,7 @@ public struct AppClipDefaultExperienceLocalizationUpdateRequest: Codable, Equata
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appClipDefaultExperienceLocalizations, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageRequest.swift
@@ -16,7 +16,7 @@ public struct AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageRequest: 
             case appStoreVersions
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .appStoreVersions, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageResponse.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageResponse.swift
@@ -17,7 +17,7 @@ public struct AppClipDefaultExperienceReleaseWithAppStoreVersionLinkageResponse:
             case appStoreVersions
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .appStoreVersions, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/AppClipDefaultExperienceUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipDefaultExperienceUpdateRequest.swift
@@ -40,7 +40,7 @@ public struct AppClipDefaultExperienceUpdateRequest: Codable, Equatable {
                         case appStoreVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -56,7 +56,7 @@ public struct AppClipDefaultExperienceUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
+        public init(type: `Type` = .appClipDefaultExperiences, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppClipDomainStatus.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipDomainStatus.swift
@@ -58,7 +58,7 @@ public struct AppClipDomainStatus: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appClipDomainStatuses, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppClipHeaderImage.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipHeaderImage.swift
@@ -64,7 +64,7 @@ public struct AppClipHeaderImage: Codable, Equatable, Identifiable {
                     case appClipDefaultExperienceLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appClipDefaultExperienceLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -81,7 +81,7 @@ public struct AppClipHeaderImage: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appClipHeaderImages, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppClipHeaderImageCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipHeaderImageCreateRequest.swift
@@ -41,7 +41,7 @@ public struct AppClipHeaderImageCreateRequest: Codable, Equatable {
                         case appClipDefaultExperienceLocalizations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appClipDefaultExperienceLocalizations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct AppClipHeaderImageCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appClipHeaderImages, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppClipHeaderImageUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppClipHeaderImageUpdateRequest.swift
@@ -32,7 +32,7 @@ public struct AppClipHeaderImageUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appClipHeaderImages, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppCustomProductPage.swift
+++ b/Sources/_Specification/Generated/Entities/AppCustomProductPage.swift
@@ -65,7 +65,7 @@ public struct AppCustomProductPage: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -105,7 +105,7 @@ public struct AppCustomProductPage: Codable, Equatable, Identifiable {
                     case appCustomProductPageVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCustomProductPageVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -124,7 +124,7 @@ public struct AppCustomProductPage: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appCustomProductPages, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppCustomProductPageCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppCustomProductPageCreateRequest.swift
@@ -43,7 +43,7 @@ public struct AppCustomProductPageCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -65,7 +65,7 @@ public struct AppCustomProductPageCreateRequest: Codable, Equatable {
                         case appCustomProductPageVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appCustomProductPageVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -87,7 +87,7 @@ public struct AppCustomProductPageCreateRequest: Codable, Equatable {
                         case appStoreVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -109,7 +109,7 @@ public struct AppCustomProductPageCreateRequest: Codable, Equatable {
                         case appCustomProductPages
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appCustomProductPages, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -128,7 +128,7 @@ public struct AppCustomProductPageCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appCustomProductPages, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppCustomProductPageLocalization.swift
+++ b/Sources/_Specification/Generated/Entities/AppCustomProductPageLocalization.swift
@@ -58,7 +58,7 @@ public struct AppCustomProductPageLocalization: Codable, Equatable, Identifiable
                     case appCustomProductPageVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCustomProductPageVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -98,7 +98,7 @@ public struct AppCustomProductPageLocalization: Codable, Equatable, Identifiable
                     case appScreenshotSets
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appScreenshotSets, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -139,7 +139,7 @@ public struct AppCustomProductPageLocalization: Codable, Equatable, Identifiable
                     case appPreviewSets
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appPreviewSets, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -159,7 +159,7 @@ public struct AppCustomProductPageLocalization: Codable, Equatable, Identifiable
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appCustomProductPageLocalizations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppCustomProductPageLocalizationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppCustomProductPageLocalizationCreateRequest.swift
@@ -41,7 +41,7 @@ public struct AppCustomProductPageLocalizationCreateRequest: Codable, Equatable 
                         case appCustomProductPageVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appCustomProductPageVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct AppCustomProductPageLocalizationCreateRequest: Codable, Equatable 
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appCustomProductPageLocalizations, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppCustomProductPageLocalizationInlineCreate.swift
+++ b/Sources/_Specification/Generated/Entities/AppCustomProductPageLocalizationInlineCreate.swift
@@ -39,7 +39,7 @@ public struct AppCustomProductPageLocalizationInlineCreate: Codable, Equatable, 
                     case appCustomProductPageVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCustomProductPageVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -55,7 +55,7 @@ public struct AppCustomProductPageLocalizationInlineCreate: Codable, Equatable, 
         }
     }
 
-    public init(type: `Type`, id: String? = nil, attributes: Attributes, relationships: Relationships? = nil) {
+    public init(type: `Type` = .appCustomProductPageLocalizations, id: String? = nil, attributes: Attributes, relationships: Relationships? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppCustomProductPageLocalizationUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppCustomProductPageLocalizationUpdateRequest.swift
@@ -25,7 +25,7 @@ public struct AppCustomProductPageLocalizationUpdateRequest: Codable, Equatable 
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appCustomProductPageLocalizations, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppCustomProductPageUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppCustomProductPageUpdateRequest.swift
@@ -32,7 +32,7 @@ public struct AppCustomProductPageUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appCustomProductPages, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppCustomProductPageVersion.swift
+++ b/Sources/_Specification/Generated/Entities/AppCustomProductPageVersion.swift
@@ -68,7 +68,7 @@ public struct AppCustomProductPageVersion: Codable, Equatable, Identifiable {
                     case appCustomProductPages
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCustomProductPages, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -108,7 +108,7 @@ public struct AppCustomProductPageVersion: Codable, Equatable, Identifiable {
                     case appCustomProductPageLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCustomProductPageLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -127,7 +127,7 @@ public struct AppCustomProductPageVersion: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appCustomProductPageVersions, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppCustomProductPageVersionCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppCustomProductPageVersionCreateRequest.swift
@@ -31,7 +31,7 @@ public struct AppCustomProductPageVersionCreateRequest: Codable, Equatable {
                         case appCustomProductPages
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appCustomProductPages, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -53,7 +53,7 @@ public struct AppCustomProductPageVersionCreateRequest: Codable, Equatable {
                         case appCustomProductPageLocalizations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appCustomProductPageLocalizations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -70,7 +70,7 @@ public struct AppCustomProductPageVersionCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .appCustomProductPageVersions, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/AppCustomProductPageVersionInlineCreate.swift
+++ b/Sources/_Specification/Generated/Entities/AppCustomProductPageVersionInlineCreate.swift
@@ -29,7 +29,7 @@ public struct AppCustomProductPageVersionInlineCreate: Codable, Equatable, Ident
                     case appCustomProductPages
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCustomProductPages, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -51,7 +51,7 @@ public struct AppCustomProductPageVersionInlineCreate: Codable, Equatable, Ident
                     case appCustomProductPageLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCustomProductPageLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -68,7 +68,7 @@ public struct AppCustomProductPageVersionInlineCreate: Codable, Equatable, Ident
         }
     }
 
-    public init(type: `Type`, id: String? = nil, relationships: Relationships? = nil) {
+    public init(type: `Type` = .appCustomProductPageVersions, id: String? = nil, relationships: Relationships? = nil) {
         self.type = type
         self.id = id
         self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppEncryptionDeclaration.swift
+++ b/Sources/_Specification/Generated/Entities/AppEncryptionDeclaration.swift
@@ -99,7 +99,7 @@ public struct AppEncryptionDeclaration: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -139,7 +139,7 @@ public struct AppEncryptionDeclaration: Codable, Equatable, Identifiable {
                     case builds
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .builds, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -179,7 +179,7 @@ public struct AppEncryptionDeclaration: Codable, Equatable, Identifiable {
                     case appEncryptionDeclarationDocuments
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appEncryptionDeclarationDocuments, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -198,7 +198,7 @@ public struct AppEncryptionDeclaration: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appEncryptionDeclarations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppEncryptionDeclarationBuildsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppEncryptionDeclarationBuildsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct AppEncryptionDeclarationBuildsLinkagesRequest: Codable, Equatable 
             case builds
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .builds, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/AppEncryptionDeclarationDocument.swift
+++ b/Sources/_Specification/Generated/Entities/AppEncryptionDeclarationDocument.swift
@@ -45,7 +45,7 @@ public struct AppEncryptionDeclarationDocument: Codable, Equatable, Identifiable
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appEncryptionDeclarationDocuments, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppEncryptionDeclarationDocumentCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppEncryptionDeclarationDocumentCreateRequest.swift
@@ -41,7 +41,7 @@ public struct AppEncryptionDeclarationDocumentCreateRequest: Codable, Equatable 
                         case appEncryptionDeclarations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appEncryptionDeclarations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct AppEncryptionDeclarationDocumentCreateRequest: Codable, Equatable 
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appEncryptionDeclarationDocuments, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppEncryptionDeclarationDocumentUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppEncryptionDeclarationDocumentUpdateRequest.swift
@@ -32,7 +32,7 @@ public struct AppEncryptionDeclarationDocumentUpdateRequest: Codable, Equatable 
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appEncryptionDeclarationDocuments, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppEvent.swift
+++ b/Sources/_Specification/Generated/Entities/AppEvent.swift
@@ -144,7 +144,7 @@ public struct AppEvent: Codable, Equatable, Identifiable {
                     case appEventLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appEventLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -162,7 +162,7 @@ public struct AppEvent: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appEvents, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppEventCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppEventCreateRequest.swift
@@ -97,7 +97,7 @@ public struct AppEventCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -113,7 +113,7 @@ public struct AppEventCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appEvents, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppEventLocalization.swift
+++ b/Sources/_Specification/Generated/Entities/AppEventLocalization.swift
@@ -62,7 +62,7 @@ public struct AppEventLocalization: Codable, Equatable, Identifiable {
                     case appEvents
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appEvents, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -102,7 +102,7 @@ public struct AppEventLocalization: Codable, Equatable, Identifiable {
                     case appEventScreenshots
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appEventScreenshots, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -143,7 +143,7 @@ public struct AppEventLocalization: Codable, Equatable, Identifiable {
                     case appEventVideoClips
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appEventVideoClips, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -163,7 +163,7 @@ public struct AppEventLocalization: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appEventLocalizations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppEventLocalizationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppEventLocalizationCreateRequest.swift
@@ -45,7 +45,7 @@ public struct AppEventLocalizationCreateRequest: Codable, Equatable {
                         case appEvents
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appEvents, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -61,7 +61,7 @@ public struct AppEventLocalizationCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appEventLocalizations, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppEventLocalizationUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppEventLocalizationUpdateRequest.swift
@@ -29,7 +29,7 @@ public struct AppEventLocalizationUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appEventLocalizations, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppEventScreenshot.swift
+++ b/Sources/_Specification/Generated/Entities/AppEventScreenshot.swift
@@ -66,7 +66,7 @@ public struct AppEventScreenshot: Codable, Equatable, Identifiable {
                     case appEventLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appEventLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -83,7 +83,7 @@ public struct AppEventScreenshot: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appEventScreenshots, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppEventScreenshotCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppEventScreenshotCreateRequest.swift
@@ -43,7 +43,7 @@ public struct AppEventScreenshotCreateRequest: Codable, Equatable {
                         case appEventLocalizations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appEventLocalizations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -59,7 +59,7 @@ public struct AppEventScreenshotCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appEventScreenshots, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppEventScreenshotUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppEventScreenshotUpdateRequest.swift
@@ -29,7 +29,7 @@ public struct AppEventScreenshotUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appEventScreenshots, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppEventUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppEventUpdateRequest.swift
@@ -83,7 +83,7 @@ public struct AppEventUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appEvents, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppEventVideoClip.swift
+++ b/Sources/_Specification/Generated/Entities/AppEventVideoClip.swift
@@ -79,7 +79,7 @@ public struct AppEventVideoClip: Codable, Equatable, Identifiable {
                     case appEventLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appEventLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -96,7 +96,7 @@ public struct AppEventVideoClip: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appEventVideoClips, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppEventVideoClipCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppEventVideoClipCreateRequest.swift
@@ -45,7 +45,7 @@ public struct AppEventVideoClipCreateRequest: Codable, Equatable {
                         case appEventLocalizations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appEventLocalizations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -61,7 +61,7 @@ public struct AppEventVideoClipCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appEventVideoClips, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppEventVideoClipUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppEventVideoClipUpdateRequest.swift
@@ -32,7 +32,7 @@ public struct AppEventVideoClipUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appEventVideoClips, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppInfo.swift
+++ b/Sources/_Specification/Generated/Entities/AppInfo.swift
@@ -100,7 +100,7 @@ public struct AppInfo: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -139,7 +139,7 @@ public struct AppInfo: Codable, Equatable, Identifiable {
                     case ageRatingDeclarations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .ageRatingDeclarations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -179,7 +179,7 @@ public struct AppInfo: Codable, Equatable, Identifiable {
                     case appInfoLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appInfoLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -219,7 +219,7 @@ public struct AppInfo: Codable, Equatable, Identifiable {
                     case appCategories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCategories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -258,7 +258,7 @@ public struct AppInfo: Codable, Equatable, Identifiable {
                     case appCategories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCategories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -297,7 +297,7 @@ public struct AppInfo: Codable, Equatable, Identifiable {
                     case appCategories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCategories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -336,7 +336,7 @@ public struct AppInfo: Codable, Equatable, Identifiable {
                     case appCategories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCategories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -375,7 +375,7 @@ public struct AppInfo: Codable, Equatable, Identifiable {
                     case appCategories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCategories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -414,7 +414,7 @@ public struct AppInfo: Codable, Equatable, Identifiable {
                     case appCategories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCategories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -439,7 +439,7 @@ public struct AppInfo: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appInfos, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppInfoLocalization.swift
+++ b/Sources/_Specification/Generated/Entities/AppInfoLocalization.swift
@@ -73,7 +73,7 @@ public struct AppInfoLocalization: Codable, Equatable, Identifiable {
                     case appInfos
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appInfos, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -90,7 +90,7 @@ public struct AppInfoLocalization: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appInfoLocalizations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppInfoLocalizationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppInfoLocalizationCreateRequest.swift
@@ -58,7 +58,7 @@ public struct AppInfoLocalizationCreateRequest: Codable, Equatable {
                         case appInfos
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appInfos, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -74,7 +74,7 @@ public struct AppInfoLocalizationCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appInfoLocalizations, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppInfoLocalizationUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppInfoLocalizationUpdateRequest.swift
@@ -41,7 +41,7 @@ public struct AppInfoLocalizationUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appInfoLocalizations, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppInfoUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppInfoUpdateRequest.swift
@@ -36,7 +36,7 @@ public struct AppInfoUpdateRequest: Codable, Equatable {
                         case appCategories
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appCategories, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -58,7 +58,7 @@ public struct AppInfoUpdateRequest: Codable, Equatable {
                         case appCategories
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appCategories, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -80,7 +80,7 @@ public struct AppInfoUpdateRequest: Codable, Equatable {
                         case appCategories
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appCategories, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -102,7 +102,7 @@ public struct AppInfoUpdateRequest: Codable, Equatable {
                         case appCategories
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appCategories, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -124,7 +124,7 @@ public struct AppInfoUpdateRequest: Codable, Equatable {
                         case appCategories
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appCategories, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -146,7 +146,7 @@ public struct AppInfoUpdateRequest: Codable, Equatable {
                         case appCategories
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appCategories, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -167,7 +167,7 @@ public struct AppInfoUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, relationships: Relationships? = nil) {
+        public init(type: `Type` = .appInfos, id: String, relationships: Relationships? = nil) {
             self.type = type
             self.id = id
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppPreOrder.swift
+++ b/Sources/_Specification/Generated/Entities/AppPreOrder.swift
@@ -56,7 +56,7 @@ public struct AppPreOrder: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -73,7 +73,7 @@ public struct AppPreOrder: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appPreOrders, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppPreOrderCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppPreOrderCreateRequest.swift
@@ -39,7 +39,7 @@ public struct AppPreOrderCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -55,7 +55,7 @@ public struct AppPreOrderCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes? = nil, relationships: Relationships) {
+        public init(type: `Type` = .appPreOrders, attributes: Attributes? = nil, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppPreOrderUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppPreOrderUpdateRequest.swift
@@ -25,7 +25,7 @@ public struct AppPreOrderUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appPreOrders, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppPreview.swift
+++ b/Sources/_Specification/Generated/Entities/AppPreview.swift
@@ -82,7 +82,7 @@ public struct AppPreview: Codable, Equatable, Identifiable {
                     case appPreviewSets
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appPreviewSets, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -99,7 +99,7 @@ public struct AppPreview: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appPreviews, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppPreviewCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppPreviewCreateRequest.swift
@@ -45,7 +45,7 @@ public struct AppPreviewCreateRequest: Codable, Equatable {
                         case appPreviewSets
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appPreviewSets, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -61,7 +61,7 @@ public struct AppPreviewCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appPreviews, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppPreviewSet.swift
+++ b/Sources/_Specification/Generated/Entities/AppPreviewSet.swift
@@ -57,7 +57,7 @@ public struct AppPreviewSet: Codable, Equatable, Identifiable {
                     case appStoreVersionLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -96,7 +96,7 @@ public struct AppPreviewSet: Codable, Equatable, Identifiable {
                     case appCustomProductPageLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCustomProductPageLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -135,7 +135,7 @@ public struct AppPreviewSet: Codable, Equatable, Identifiable {
                     case appStoreVersionExperimentTreatmentLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionExperimentTreatmentLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -175,7 +175,7 @@ public struct AppPreviewSet: Codable, Equatable, Identifiable {
                     case appPreviews
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appPreviews, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -196,7 +196,7 @@ public struct AppPreviewSet: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appPreviewSets, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppPreviewSetAppPreviewsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppPreviewSetAppPreviewsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct AppPreviewSetAppPreviewsLinkagesRequest: Codable, Equatable {
             case appPreviews
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .appPreviews, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/AppPreviewSetAppPreviewsLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/AppPreviewSetAppPreviewsLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct AppPreviewSetAppPreviewsLinkagesResponse: Codable, Equatable {
             case appPreviews
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .appPreviews, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/AppPreviewSetCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppPreviewSetCreateRequest.swift
@@ -41,7 +41,7 @@ public struct AppPreviewSetCreateRequest: Codable, Equatable {
                         case appStoreVersionLocalizations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersionLocalizations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -63,7 +63,7 @@ public struct AppPreviewSetCreateRequest: Codable, Equatable {
                         case appCustomProductPageLocalizations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appCustomProductPageLocalizations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -85,7 +85,7 @@ public struct AppPreviewSetCreateRequest: Codable, Equatable {
                         case appStoreVersionExperimentTreatmentLocalizations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersionExperimentTreatmentLocalizations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -103,7 +103,7 @@ public struct AppPreviewSetCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships? = nil) {
+        public init(type: `Type` = .appPreviewSets, attributes: Attributes, relationships: Relationships? = nil) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppPreviewUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppPreviewUpdateRequest.swift
@@ -35,7 +35,7 @@ public struct AppPreviewUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appPreviews, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppPrice.swift
+++ b/Sources/_Specification/Generated/Entities/AppPrice.swift
@@ -46,7 +46,7 @@ public struct AppPrice: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -85,7 +85,7 @@ public struct AppPrice: Codable, Equatable, Identifiable {
                     case appPriceTiers
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appPriceTiers, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -103,7 +103,7 @@ public struct AppPrice: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appPrices, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppPriceInlineCreate.swift
+++ b/Sources/_Specification/Generated/Entities/AppPriceInlineCreate.swift
@@ -13,7 +13,7 @@ public struct AppPriceInlineCreate: Codable, Equatable, Identifiable {
         case appPrices
     }
 
-    public init(type: `Type`, id: String? = nil) {
+    public init(type: `Type` = .appPrices, id: String? = nil) {
         self.type = type
         self.id = id
     }

--- a/Sources/_Specification/Generated/Entities/AppPricePoint.swift
+++ b/Sources/_Specification/Generated/Entities/AppPricePoint.swift
@@ -57,7 +57,7 @@ public struct AppPricePoint: Codable, Equatable, Identifiable {
                     case appPriceTiers
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appPriceTiers, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -96,7 +96,7 @@ public struct AppPricePoint: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -114,7 +114,7 @@ public struct AppPricePoint: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appPricePoints, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppPricePointV2.swift
+++ b/Sources/_Specification/Generated/Entities/AppPricePointV2.swift
@@ -58,7 +58,7 @@ public struct AppPricePointV2: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -97,7 +97,7 @@ public struct AppPricePointV2: Codable, Equatable, Identifiable {
                     case appPriceTiers
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appPriceTiers, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -136,7 +136,7 @@ public struct AppPricePointV2: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -155,7 +155,7 @@ public struct AppPricePointV2: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appPricePoints, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppPricePointV3.swift
+++ b/Sources/_Specification/Generated/Entities/AppPricePointV3.swift
@@ -57,7 +57,7 @@ public struct AppPricePointV3: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -96,7 +96,7 @@ public struct AppPricePointV3: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -114,7 +114,7 @@ public struct AppPricePointV3: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appPricePoints, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppPriceSchedule.swift
+++ b/Sources/_Specification/Generated/Entities/AppPriceSchedule.swift
@@ -48,7 +48,7 @@ public struct AppPriceSchedule: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -87,7 +87,7 @@ public struct AppPriceSchedule: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -127,7 +127,7 @@ public struct AppPriceSchedule: Codable, Equatable, Identifiable {
                     case appPrices
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appPrices, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -168,7 +168,7 @@ public struct AppPriceSchedule: Codable, Equatable, Identifiable {
                     case appPrices
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appPrices, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -189,7 +189,7 @@ public struct AppPriceSchedule: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appPriceSchedules, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppPriceScheduleCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppPriceScheduleCreateRequest.swift
@@ -33,7 +33,7 @@ public struct AppPriceScheduleCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -55,7 +55,7 @@ public struct AppPriceScheduleCreateRequest: Codable, Equatable {
                         case territories
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .territories, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -77,7 +77,7 @@ public struct AppPriceScheduleCreateRequest: Codable, Equatable {
                         case appPrices
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appPrices, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -95,7 +95,7 @@ public struct AppPriceScheduleCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .appPriceSchedules, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/AppPriceTier.swift
+++ b/Sources/_Specification/Generated/Entities/AppPriceTier.swift
@@ -46,7 +46,7 @@ public struct AppPriceTier: Codable, Equatable, Identifiable {
                     case appPricePoints
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appPricePoints, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -64,7 +64,7 @@ public struct AppPriceTier: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appPriceTiers, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppPriceV2.swift
+++ b/Sources/_Specification/Generated/Entities/AppPriceV2.swift
@@ -65,7 +65,7 @@ public struct AppPriceV2: Codable, Equatable, Identifiable {
                     case appPricePoints
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appPricePoints, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -104,7 +104,7 @@ public struct AppPriceV2: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -122,7 +122,7 @@ public struct AppPriceV2: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appPrices, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppPriceV2InlineCreate.swift
+++ b/Sources/_Specification/Generated/Entities/AppPriceV2InlineCreate.swift
@@ -13,7 +13,7 @@ public struct AppPriceV2InlineCreate: Codable, Equatable, Identifiable {
         case appPrices
     }
 
-    public init(type: `Type`, id: String? = nil) {
+    public init(type: `Type` = .appPrices, id: String? = nil) {
         self.type = type
         self.id = id
     }

--- a/Sources/_Specification/Generated/Entities/AppPromotedPurchasesLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppPromotedPurchasesLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct AppPromotedPurchasesLinkagesRequest: Codable, Equatable {
             case promotedPurchases
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .promotedPurchases, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/AppPromotedPurchasesLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/AppPromotedPurchasesLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct AppPromotedPurchasesLinkagesResponse: Codable, Equatable {
             case promotedPurchases
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .promotedPurchases, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/AppScreenshot.swift
+++ b/Sources/_Specification/Generated/Entities/AppScreenshot.swift
@@ -68,7 +68,7 @@ public struct AppScreenshot: Codable, Equatable, Identifiable {
                     case appScreenshotSets
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appScreenshotSets, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -85,7 +85,7 @@ public struct AppScreenshot: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appScreenshots, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppScreenshotCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppScreenshotCreateRequest.swift
@@ -41,7 +41,7 @@ public struct AppScreenshotCreateRequest: Codable, Equatable {
                         case appScreenshotSets
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appScreenshotSets, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct AppScreenshotCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appScreenshots, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppScreenshotSet.swift
+++ b/Sources/_Specification/Generated/Entities/AppScreenshotSet.swift
@@ -57,7 +57,7 @@ public struct AppScreenshotSet: Codable, Equatable, Identifiable {
                     case appStoreVersionLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -96,7 +96,7 @@ public struct AppScreenshotSet: Codable, Equatable, Identifiable {
                     case appCustomProductPageLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCustomProductPageLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -135,7 +135,7 @@ public struct AppScreenshotSet: Codable, Equatable, Identifiable {
                     case appStoreVersionExperimentTreatmentLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionExperimentTreatmentLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -175,7 +175,7 @@ public struct AppScreenshotSet: Codable, Equatable, Identifiable {
                     case appScreenshots
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appScreenshots, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -196,7 +196,7 @@ public struct AppScreenshotSet: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appScreenshotSets, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppScreenshotSetAppScreenshotsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppScreenshotSetAppScreenshotsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct AppScreenshotSetAppScreenshotsLinkagesRequest: Codable, Equatable 
             case appScreenshots
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .appScreenshots, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/AppScreenshotSetAppScreenshotsLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/AppScreenshotSetAppScreenshotsLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct AppScreenshotSetAppScreenshotsLinkagesResponse: Codable, Equatable
             case appScreenshots
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .appScreenshots, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/AppScreenshotSetCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppScreenshotSetCreateRequest.swift
@@ -41,7 +41,7 @@ public struct AppScreenshotSetCreateRequest: Codable, Equatable {
                         case appStoreVersionLocalizations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersionLocalizations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -63,7 +63,7 @@ public struct AppScreenshotSetCreateRequest: Codable, Equatable {
                         case appCustomProductPageLocalizations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appCustomProductPageLocalizations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -85,7 +85,7 @@ public struct AppScreenshotSetCreateRequest: Codable, Equatable {
                         case appStoreVersionExperimentTreatmentLocalizations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersionExperimentTreatmentLocalizations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -103,7 +103,7 @@ public struct AppScreenshotSetCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships? = nil) {
+        public init(type: `Type` = .appScreenshotSets, attributes: Attributes, relationships: Relationships? = nil) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppScreenshotUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppScreenshotUpdateRequest.swift
@@ -32,7 +32,7 @@ public struct AppScreenshotUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appScreenshots, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppStoreReviewAttachment.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreReviewAttachment.swift
@@ -62,7 +62,7 @@ public struct AppStoreReviewAttachment: Codable, Equatable, Identifiable {
                     case appStoreReviewDetails
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreReviewDetails, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -79,7 +79,7 @@ public struct AppStoreReviewAttachment: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appStoreReviewAttachments, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppStoreReviewAttachmentCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreReviewAttachmentCreateRequest.swift
@@ -41,7 +41,7 @@ public struct AppStoreReviewAttachmentCreateRequest: Codable, Equatable {
                         case appStoreReviewDetails
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreReviewDetails, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct AppStoreReviewAttachmentCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appStoreReviewAttachments, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppStoreReviewAttachmentUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreReviewAttachmentUpdateRequest.swift
@@ -32,7 +32,7 @@ public struct AppStoreReviewAttachmentUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appStoreReviewAttachments, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppStoreReviewDetail.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreReviewDetail.swift
@@ -80,7 +80,7 @@ public struct AppStoreReviewDetail: Codable, Equatable, Identifiable {
                     case appStoreVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -120,7 +120,7 @@ public struct AppStoreReviewDetail: Codable, Equatable, Identifiable {
                     case appStoreReviewAttachments
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreReviewAttachments, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -139,7 +139,7 @@ public struct AppStoreReviewDetail: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appStoreReviewDetails, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppStoreReviewDetailCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreReviewDetailCreateRequest.swift
@@ -64,7 +64,7 @@ public struct AppStoreReviewDetailCreateRequest: Codable, Equatable {
                         case appStoreVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -80,7 +80,7 @@ public struct AppStoreReviewDetailCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes? = nil, relationships: Relationships) {
+        public init(type: `Type` = .appStoreReviewDetails, attributes: Attributes? = nil, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppStoreReviewDetailUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreReviewDetailUpdateRequest.swift
@@ -50,7 +50,7 @@ public struct AppStoreReviewDetailUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appStoreReviewDetails, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppStoreVersion.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersion.swift
@@ -107,7 +107,7 @@ public struct AppStoreVersion: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -146,7 +146,7 @@ public struct AppStoreVersion: Codable, Equatable, Identifiable {
                     case ageRatingDeclarations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .ageRatingDeclarations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -186,7 +186,7 @@ public struct AppStoreVersion: Codable, Equatable, Identifiable {
                     case appStoreVersionLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -226,7 +226,7 @@ public struct AppStoreVersion: Codable, Equatable, Identifiable {
                     case builds
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .builds, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -265,7 +265,7 @@ public struct AppStoreVersion: Codable, Equatable, Identifiable {
                     case appStoreVersionPhasedReleases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionPhasedReleases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -304,7 +304,7 @@ public struct AppStoreVersion: Codable, Equatable, Identifiable {
                     case routingAppCoverages
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .routingAppCoverages, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -343,7 +343,7 @@ public struct AppStoreVersion: Codable, Equatable, Identifiable {
                     case appStoreReviewDetails
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreReviewDetails, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -382,7 +382,7 @@ public struct AppStoreVersion: Codable, Equatable, Identifiable {
                     case appStoreVersionSubmissions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionSubmissions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -421,7 +421,7 @@ public struct AppStoreVersion: Codable, Equatable, Identifiable {
                     case appClipDefaultExperiences
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appClipDefaultExperiences, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -461,7 +461,7 @@ public struct AppStoreVersion: Codable, Equatable, Identifiable {
                     case appStoreVersionExperiments
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionExperiments, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -502,7 +502,7 @@ public struct AppStoreVersion: Codable, Equatable, Identifiable {
                     case appStoreVersionExperiments
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionExperiments, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -542,7 +542,7 @@ public struct AppStoreVersion: Codable, Equatable, Identifiable {
                     case alternativeDistributionPackages
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .alternativeDistributionPackages, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -570,7 +570,7 @@ public struct AppStoreVersion: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appStoreVersions, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionAppClipDefaultExperienceLinkageRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionAppClipDefaultExperienceLinkageRequest.swift
@@ -16,7 +16,7 @@ public struct AppStoreVersionAppClipDefaultExperienceLinkageRequest: Codable, Eq
             case appClipDefaultExperiences
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .appClipDefaultExperiences, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionAppClipDefaultExperienceLinkageResponse.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionAppClipDefaultExperienceLinkageResponse.swift
@@ -17,7 +17,7 @@ public struct AppStoreVersionAppClipDefaultExperienceLinkageResponse: Codable, E
             case appClipDefaultExperiences
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .appClipDefaultExperiences, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionBuildLinkageRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionBuildLinkageRequest.swift
@@ -16,7 +16,7 @@ public struct AppStoreVersionBuildLinkageRequest: Codable, Equatable {
             case builds
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .builds, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionBuildLinkageResponse.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionBuildLinkageResponse.swift
@@ -17,7 +17,7 @@ public struct AppStoreVersionBuildLinkageResponse: Codable, Equatable {
             case builds
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .builds, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionCreateRequest.swift
@@ -62,7 +62,7 @@ public struct AppStoreVersionCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -84,7 +84,7 @@ public struct AppStoreVersionCreateRequest: Codable, Equatable {
                         case appStoreVersionLocalizations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersionLocalizations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -106,7 +106,7 @@ public struct AppStoreVersionCreateRequest: Codable, Equatable {
                         case builds
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .builds, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -124,7 +124,7 @@ public struct AppStoreVersionCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appStoreVersions, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionExperiment.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionExperiment.swift
@@ -86,7 +86,7 @@ public struct AppStoreVersionExperiment: Codable, Equatable, Identifiable {
                     case appStoreVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -126,7 +126,7 @@ public struct AppStoreVersionExperiment: Codable, Equatable, Identifiable {
                     case appStoreVersionExperimentTreatments
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionExperimentTreatments, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -145,7 +145,7 @@ public struct AppStoreVersionExperiment: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appStoreVersionExperiments, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentCreateRequest.swift
@@ -41,7 +41,7 @@ public struct AppStoreVersionExperimentCreateRequest: Codable, Equatable {
                         case appStoreVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct AppStoreVersionExperimentCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appStoreVersionExperiments, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentTreatment.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentTreatment.swift
@@ -62,7 +62,7 @@ public struct AppStoreVersionExperimentTreatment: Codable, Equatable, Identifiab
                     case appStoreVersionExperiments
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionExperiments, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -101,7 +101,7 @@ public struct AppStoreVersionExperimentTreatment: Codable, Equatable, Identifiab
                     case appStoreVersionExperiments
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionExperiments, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -141,7 +141,7 @@ public struct AppStoreVersionExperimentTreatment: Codable, Equatable, Identifiab
                     case appStoreVersionExperimentTreatmentLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionExperimentTreatmentLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -161,7 +161,7 @@ public struct AppStoreVersionExperimentTreatment: Codable, Equatable, Identifiab
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appStoreVersionExperimentTreatments, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentTreatmentCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentTreatmentCreateRequest.swift
@@ -42,7 +42,7 @@ public struct AppStoreVersionExperimentTreatmentCreateRequest: Codable, Equatabl
                         case appStoreVersionExperiments
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersionExperiments, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -64,7 +64,7 @@ public struct AppStoreVersionExperimentTreatmentCreateRequest: Codable, Equatabl
                         case appStoreVersionExperiments
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersionExperiments, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -81,7 +81,7 @@ public struct AppStoreVersionExperimentTreatmentCreateRequest: Codable, Equatabl
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appStoreVersionExperimentTreatments, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentTreatmentLocalization.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentTreatmentLocalization.swift
@@ -56,7 +56,7 @@ public struct AppStoreVersionExperimentTreatmentLocalization: Codable, Equatable
                     case appStoreVersionExperimentTreatments
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionExperimentTreatments, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -96,7 +96,7 @@ public struct AppStoreVersionExperimentTreatmentLocalization: Codable, Equatable
                     case appScreenshotSets
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appScreenshotSets, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -137,7 +137,7 @@ public struct AppStoreVersionExperimentTreatmentLocalization: Codable, Equatable
                     case appPreviewSets
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appPreviewSets, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -157,7 +157,7 @@ public struct AppStoreVersionExperimentTreatmentLocalization: Codable, Equatable
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appStoreVersionExperimentTreatmentLocalizations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentTreatmentLocalizationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentTreatmentLocalizationCreateRequest.swift
@@ -39,7 +39,7 @@ public struct AppStoreVersionExperimentTreatmentLocalizationCreateRequest: Codab
                         case appStoreVersionExperimentTreatments
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersionExperimentTreatments, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -55,7 +55,7 @@ public struct AppStoreVersionExperimentTreatmentLocalizationCreateRequest: Codab
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appStoreVersionExperimentTreatmentLocalizations, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentTreatmentUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentTreatmentUpdateRequest.swift
@@ -27,7 +27,7 @@ public struct AppStoreVersionExperimentTreatmentUpdateRequest: Codable, Equatabl
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appStoreVersionExperimentTreatments, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentUpdateRequest.swift
@@ -35,7 +35,7 @@ public struct AppStoreVersionExperimentUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appStoreVersionExperiments, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentV2.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentV2.swift
@@ -91,7 +91,7 @@ public struct AppStoreVersionExperimentV2: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -130,7 +130,7 @@ public struct AppStoreVersionExperimentV2: Codable, Equatable, Identifiable {
                     case appStoreVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -170,7 +170,7 @@ public struct AppStoreVersionExperimentV2: Codable, Equatable, Identifiable {
                     case appStoreVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -211,7 +211,7 @@ public struct AppStoreVersionExperimentV2: Codable, Equatable, Identifiable {
                     case appStoreVersionExperimentTreatments
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionExperimentTreatments, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -232,7 +232,7 @@ public struct AppStoreVersionExperimentV2: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appStoreVersionExperiments, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentV2CreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentV2CreateRequest.swift
@@ -43,7 +43,7 @@ public struct AppStoreVersionExperimentV2CreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -59,7 +59,7 @@ public struct AppStoreVersionExperimentV2CreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appStoreVersionExperiments, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentV2UpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionExperimentV2UpdateRequest.swift
@@ -35,7 +35,7 @@ public struct AppStoreVersionExperimentV2UpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appStoreVersionExperiments, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionLocalization.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionLocalization.swift
@@ -78,7 +78,7 @@ public struct AppStoreVersionLocalization: Codable, Equatable, Identifiable {
                     case appStoreVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -118,7 +118,7 @@ public struct AppStoreVersionLocalization: Codable, Equatable, Identifiable {
                     case appScreenshotSets
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appScreenshotSets, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -159,7 +159,7 @@ public struct AppStoreVersionLocalization: Codable, Equatable, Identifiable {
                     case appPreviewSets
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appPreviewSets, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -179,7 +179,7 @@ public struct AppStoreVersionLocalization: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appStoreVersionLocalizations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionLocalizationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionLocalizationCreateRequest.swift
@@ -61,7 +61,7 @@ public struct AppStoreVersionLocalizationCreateRequest: Codable, Equatable {
                         case appStoreVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -77,7 +77,7 @@ public struct AppStoreVersionLocalizationCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .appStoreVersionLocalizations, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionLocalizationUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionLocalizationUpdateRequest.swift
@@ -44,7 +44,7 @@ public struct AppStoreVersionLocalizationUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appStoreVersionLocalizations, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionPhasedRelease.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionPhasedRelease.swift
@@ -29,7 +29,7 @@ public struct AppStoreVersionPhasedRelease: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appStoreVersionPhasedReleases, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionPhasedReleaseCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionPhasedReleaseCreateRequest.swift
@@ -39,7 +39,7 @@ public struct AppStoreVersionPhasedReleaseCreateRequest: Codable, Equatable {
                         case appStoreVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -55,7 +55,7 @@ public struct AppStoreVersionPhasedReleaseCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes? = nil, relationships: Relationships) {
+        public init(type: `Type` = .appStoreVersionPhasedReleases, attributes: Attributes? = nil, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionPhasedReleaseUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionPhasedReleaseUpdateRequest.swift
@@ -25,7 +25,7 @@ public struct AppStoreVersionPhasedReleaseUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .appStoreVersionPhasedReleases, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionPromotion.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionPromotion.swift
@@ -14,7 +14,7 @@ public struct AppStoreVersionPromotion: Codable, Equatable, Identifiable {
         case appStoreVersionPromotions
     }
 
-    public init(type: `Type`, id: String, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appStoreVersionPromotions, id: String, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.links = links

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionPromotionCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionPromotionCreateRequest.swift
@@ -31,7 +31,7 @@ public struct AppStoreVersionPromotionCreateRequest: Codable, Equatable {
                         case appStoreVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -53,7 +53,7 @@ public struct AppStoreVersionPromotionCreateRequest: Codable, Equatable {
                         case appStoreVersionExperimentTreatments
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersionExperimentTreatments, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -70,7 +70,7 @@ public struct AppStoreVersionPromotionCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .appStoreVersionPromotions, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionReleaseRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionReleaseRequest.swift
@@ -14,7 +14,7 @@ public struct AppStoreVersionReleaseRequest: Codable, Equatable, Identifiable {
         case appStoreVersionReleaseRequests
     }
 
-    public init(type: `Type`, id: String, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appStoreVersionReleaseRequests, id: String, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.links = links

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionReleaseRequestCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionReleaseRequestCreateRequest.swift
@@ -30,7 +30,7 @@ public struct AppStoreVersionReleaseRequestCreateRequest: Codable, Equatable {
                         case appStoreVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -46,7 +46,7 @@ public struct AppStoreVersionReleaseRequestCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .appStoreVersionReleaseRequests, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionSubmission.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionSubmission.swift
@@ -45,7 +45,7 @@ public struct AppStoreVersionSubmission: Codable, Equatable, Identifiable {
                     case appStoreVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -62,7 +62,7 @@ public struct AppStoreVersionSubmission: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .appStoreVersionSubmissions, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionSubmissionCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionSubmissionCreateRequest.swift
@@ -30,7 +30,7 @@ public struct AppStoreVersionSubmissionCreateRequest: Codable, Equatable {
                         case appStoreVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -46,7 +46,7 @@ public struct AppStoreVersionSubmissionCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .appStoreVersionSubmissions, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/AppStoreVersionUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppStoreVersionUpdateRequest.swift
@@ -71,7 +71,7 @@ public struct AppStoreVersionUpdateRequest: Codable, Equatable {
                         case builds
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .builds, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -93,7 +93,7 @@ public struct AppStoreVersionUpdateRequest: Codable, Equatable {
                         case appClipDefaultExperiences
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appClipDefaultExperiences, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -110,7 +110,7 @@ public struct AppStoreVersionUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
+        public init(type: `Type` = .appStoreVersions, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/AppUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/AppUpdateRequest.swift
@@ -72,7 +72,7 @@ public struct AppUpdateRequest: Codable, Equatable {
                         case appPrices
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appPrices, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -94,7 +94,7 @@ public struct AppUpdateRequest: Codable, Equatable {
                         case territories
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .territories, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -111,7 +111,7 @@ public struct AppUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
+        public init(type: `Type` = .apps, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaAppClipInvocation.swift
+++ b/Sources/_Specification/Generated/Entities/BetaAppClipInvocation.swift
@@ -55,7 +55,7 @@ public struct BetaAppClipInvocation: Codable, Equatable, Identifiable {
                     case betaAppClipInvocationLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .betaAppClipInvocationLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -73,7 +73,7 @@ public struct BetaAppClipInvocation: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .betaAppClipInvocations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaAppClipInvocationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaAppClipInvocationCreateRequest.swift
@@ -41,7 +41,7 @@ public struct BetaAppClipInvocationCreateRequest: Codable, Equatable {
                         case buildBundles
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .buildBundles, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -63,7 +63,7 @@ public struct BetaAppClipInvocationCreateRequest: Codable, Equatable {
                         case betaAppClipInvocationLocalizations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .betaAppClipInvocationLocalizations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -80,7 +80,7 @@ public struct BetaAppClipInvocationCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .betaAppClipInvocations, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/BetaAppClipInvocationLocalization.swift
+++ b/Sources/_Specification/Generated/Entities/BetaAppClipInvocationLocalization.swift
@@ -25,7 +25,7 @@ public struct BetaAppClipInvocationLocalization: Codable, Equatable, Identifiabl
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .betaAppClipInvocationLocalizations, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaAppClipInvocationLocalizationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaAppClipInvocationLocalizationCreateRequest.swift
@@ -41,7 +41,7 @@ public struct BetaAppClipInvocationLocalizationCreateRequest: Codable, Equatable
                         case betaAppClipInvocations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .betaAppClipInvocations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct BetaAppClipInvocationLocalizationCreateRequest: Codable, Equatable
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .betaAppClipInvocationLocalizations, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/BetaAppClipInvocationLocalizationInlineCreate.swift
+++ b/Sources/_Specification/Generated/Entities/BetaAppClipInvocationLocalizationInlineCreate.swift
@@ -39,7 +39,7 @@ public struct BetaAppClipInvocationLocalizationInlineCreate: Codable, Equatable,
                     case betaAppClipInvocations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .betaAppClipInvocations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -55,7 +55,7 @@ public struct BetaAppClipInvocationLocalizationInlineCreate: Codable, Equatable,
         }
     }
 
-    public init(type: `Type`, id: String? = nil, attributes: Attributes, relationships: Relationships? = nil) {
+    public init(type: `Type` = .betaAppClipInvocationLocalizations, id: String? = nil, attributes: Attributes, relationships: Relationships? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaAppClipInvocationLocalizationUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaAppClipInvocationLocalizationUpdateRequest.swift
@@ -25,7 +25,7 @@ public struct BetaAppClipInvocationLocalizationUpdateRequest: Codable, Equatable
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .betaAppClipInvocationLocalizations, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaAppClipInvocationUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaAppClipInvocationUpdateRequest.swift
@@ -25,7 +25,7 @@ public struct BetaAppClipInvocationUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .betaAppClipInvocations, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaAppLocalization.swift
+++ b/Sources/_Specification/Generated/Entities/BetaAppLocalization.swift
@@ -73,7 +73,7 @@ public struct BetaAppLocalization: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -90,7 +90,7 @@ public struct BetaAppLocalization: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .betaAppLocalizations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaAppLocalizationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaAppLocalizationCreateRequest.swift
@@ -58,7 +58,7 @@ public struct BetaAppLocalizationCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -74,7 +74,7 @@ public struct BetaAppLocalizationCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .betaAppLocalizations, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/BetaAppLocalizationUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaAppLocalizationUpdateRequest.swift
@@ -41,7 +41,7 @@ public struct BetaAppLocalizationUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .betaAppLocalizations, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaAppReviewDetail.swift
+++ b/Sources/_Specification/Generated/Entities/BetaAppReviewDetail.swift
@@ -79,7 +79,7 @@ public struct BetaAppReviewDetail: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -96,7 +96,7 @@ public struct BetaAppReviewDetail: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .betaAppReviewDetails, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaAppReviewDetailUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaAppReviewDetailUpdateRequest.swift
@@ -50,7 +50,7 @@ public struct BetaAppReviewDetailUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .betaAppReviewDetails, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaAppReviewSubmission.swift
+++ b/Sources/_Specification/Generated/Entities/BetaAppReviewSubmission.swift
@@ -56,7 +56,7 @@ public struct BetaAppReviewSubmission: Codable, Equatable, Identifiable {
                     case builds
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .builds, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -73,7 +73,7 @@ public struct BetaAppReviewSubmission: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .betaAppReviewSubmissions, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaAppReviewSubmissionCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaAppReviewSubmissionCreateRequest.swift
@@ -30,7 +30,7 @@ public struct BetaAppReviewSubmissionCreateRequest: Codable, Equatable {
                         case builds
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .builds, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -46,7 +46,7 @@ public struct BetaAppReviewSubmissionCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .betaAppReviewSubmissions, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/BetaBuildLocalization.swift
+++ b/Sources/_Specification/Generated/Entities/BetaBuildLocalization.swift
@@ -56,7 +56,7 @@ public struct BetaBuildLocalization: Codable, Equatable, Identifiable {
                     case builds
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .builds, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -73,7 +73,7 @@ public struct BetaBuildLocalization: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .betaBuildLocalizations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaBuildLocalizationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaBuildLocalizationCreateRequest.swift
@@ -41,7 +41,7 @@ public struct BetaBuildLocalizationCreateRequest: Codable, Equatable {
                         case builds
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .builds, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct BetaBuildLocalizationCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .betaBuildLocalizations, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/BetaBuildLocalizationUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaBuildLocalizationUpdateRequest.swift
@@ -25,7 +25,7 @@ public struct BetaBuildLocalizationUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .betaBuildLocalizations, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaGroup.swift
+++ b/Sources/_Specification/Generated/Entities/BetaGroup.swift
@@ -90,7 +90,7 @@ public struct BetaGroup: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -130,7 +130,7 @@ public struct BetaGroup: Codable, Equatable, Identifiable {
                     case builds
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .builds, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -171,7 +171,7 @@ public struct BetaGroup: Codable, Equatable, Identifiable {
                     case betaTesters
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .betaTesters, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -191,7 +191,7 @@ public struct BetaGroup: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .betaGroups, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaGroupBetaTestersLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaGroupBetaTestersLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct BetaGroupBetaTestersLinkagesRequest: Codable, Equatable {
             case betaTesters
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .betaTesters, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/BetaGroupBetaTestersLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/BetaGroupBetaTestersLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct BetaGroupBetaTestersLinkagesResponse: Codable, Equatable {
             case betaTesters
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .betaTesters, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/BetaGroupBuildsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaGroupBuildsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct BetaGroupBuildsLinkagesRequest: Codable, Equatable {
             case builds
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .builds, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/BetaGroupBuildsLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/BetaGroupBuildsLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct BetaGroupBuildsLinkagesResponse: Codable, Equatable {
             case builds
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .builds, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/BetaGroupCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaGroupCreateRequest.swift
@@ -63,7 +63,7 @@ public struct BetaGroupCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -85,7 +85,7 @@ public struct BetaGroupCreateRequest: Codable, Equatable {
                         case builds
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .builds, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -107,7 +107,7 @@ public struct BetaGroupCreateRequest: Codable, Equatable {
                         case betaTesters
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .betaTesters, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -125,7 +125,7 @@ public struct BetaGroupCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .betaGroups, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/BetaGroupUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaGroupUpdateRequest.swift
@@ -44,7 +44,7 @@ public struct BetaGroupUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .betaGroups, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaLicenseAgreement.swift
+++ b/Sources/_Specification/Generated/Entities/BetaLicenseAgreement.swift
@@ -54,7 +54,7 @@ public struct BetaLicenseAgreement: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -71,7 +71,7 @@ public struct BetaLicenseAgreement: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .betaLicenseAgreements, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaLicenseAgreementUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaLicenseAgreementUpdateRequest.swift
@@ -25,7 +25,7 @@ public struct BetaLicenseAgreementUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .betaLicenseAgreements, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaTester.swift
+++ b/Sources/_Specification/Generated/Entities/BetaTester.swift
@@ -63,7 +63,7 @@ public struct BetaTester: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -104,7 +104,7 @@ public struct BetaTester: Codable, Equatable, Identifiable {
                     case betaGroups
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .betaGroups, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -145,7 +145,7 @@ public struct BetaTester: Codable, Equatable, Identifiable {
                     case builds
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .builds, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -165,7 +165,7 @@ public struct BetaTester: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .betaTesters, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BetaTesterAppsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaTesterAppsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct BetaTesterAppsLinkagesRequest: Codable, Equatable {
             case apps
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .apps, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/BetaTesterAppsLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/BetaTesterAppsLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct BetaTesterAppsLinkagesResponse: Codable, Equatable {
             case apps
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .apps, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/BetaTesterBetaGroupsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaTesterBetaGroupsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct BetaTesterBetaGroupsLinkagesRequest: Codable, Equatable {
             case betaGroups
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .betaGroups, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/BetaTesterBetaGroupsLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/BetaTesterBetaGroupsLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct BetaTesterBetaGroupsLinkagesResponse: Codable, Equatable {
             case betaGroups
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .betaGroups, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/BetaTesterBuildsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaTesterBuildsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct BetaTesterBuildsLinkagesRequest: Codable, Equatable {
             case builds
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .builds, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/BetaTesterBuildsLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/BetaTesterBuildsLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct BetaTesterBuildsLinkagesResponse: Codable, Equatable {
             case builds
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .builds, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/BetaTesterCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaTesterCreateRequest.swift
@@ -44,7 +44,7 @@ public struct BetaTesterCreateRequest: Codable, Equatable {
                         case betaGroups
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .betaGroups, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -66,7 +66,7 @@ public struct BetaTesterCreateRequest: Codable, Equatable {
                         case builds
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .builds, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -83,7 +83,7 @@ public struct BetaTesterCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships? = nil) {
+        public init(type: `Type` = .betaTesters, attributes: Attributes, relationships: Relationships? = nil) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/BetaTesterInvitation.swift
+++ b/Sources/_Specification/Generated/Entities/BetaTesterInvitation.swift
@@ -14,7 +14,7 @@ public struct BetaTesterInvitation: Codable, Equatable, Identifiable {
         case betaTesterInvitations
     }
 
-    public init(type: `Type`, id: String, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .betaTesterInvitations, id: String, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.links = links

--- a/Sources/_Specification/Generated/Entities/BetaTesterInvitationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BetaTesterInvitationCreateRequest.swift
@@ -31,7 +31,7 @@ public struct BetaTesterInvitationCreateRequest: Codable, Equatable {
                         case betaTesters
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .betaTesters, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -53,7 +53,7 @@ public struct BetaTesterInvitationCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -70,7 +70,7 @@ public struct BetaTesterInvitationCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .betaTesterInvitations, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/Build.swift
+++ b/Sources/_Specification/Generated/Entities/Build.swift
@@ -105,7 +105,7 @@ public struct Build: Codable, Equatable, Identifiable {
                     case preReleaseVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .preReleaseVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -145,7 +145,7 @@ public struct Build: Codable, Equatable, Identifiable {
                     case betaTesters
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .betaTesters, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -186,7 +186,7 @@ public struct Build: Codable, Equatable, Identifiable {
                     case betaGroups
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .betaGroups, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -227,7 +227,7 @@ public struct Build: Codable, Equatable, Identifiable {
                     case betaBuildLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .betaBuildLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -267,7 +267,7 @@ public struct Build: Codable, Equatable, Identifiable {
                     case appEncryptionDeclarations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appEncryptionDeclarations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -306,7 +306,7 @@ public struct Build: Codable, Equatable, Identifiable {
                     case betaAppReviewSubmissions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .betaAppReviewSubmissions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -345,7 +345,7 @@ public struct Build: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -384,7 +384,7 @@ public struct Build: Codable, Equatable, Identifiable {
                     case buildBetaDetails
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .buildBetaDetails, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -423,7 +423,7 @@ public struct Build: Codable, Equatable, Identifiable {
                     case appStoreVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -463,7 +463,7 @@ public struct Build: Codable, Equatable, Identifiable {
                     case buildIcons
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .buildIcons, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -504,7 +504,7 @@ public struct Build: Codable, Equatable, Identifiable {
                     case buildBundles
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .buildBundles, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -532,7 +532,7 @@ public struct Build: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .builds, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BuildAppEncryptionDeclarationLinkageRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BuildAppEncryptionDeclarationLinkageRequest.swift
@@ -16,7 +16,7 @@ public struct BuildAppEncryptionDeclarationLinkageRequest: Codable, Equatable {
             case appEncryptionDeclarations
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .appEncryptionDeclarations, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/BuildAppEncryptionDeclarationLinkageResponse.swift
+++ b/Sources/_Specification/Generated/Entities/BuildAppEncryptionDeclarationLinkageResponse.swift
@@ -17,7 +17,7 @@ public struct BuildAppEncryptionDeclarationLinkageResponse: Codable, Equatable {
             case appEncryptionDeclarations
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .appEncryptionDeclarations, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/BuildBetaDetail.swift
+++ b/Sources/_Specification/Generated/Entities/BuildBetaDetail.swift
@@ -64,7 +64,7 @@ public struct BuildBetaDetail: Codable, Equatable, Identifiable {
                     case builds
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .builds, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -81,7 +81,7 @@ public struct BuildBetaDetail: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .buildBetaDetails, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BuildBetaDetailUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BuildBetaDetailUpdateRequest.swift
@@ -29,7 +29,7 @@ public struct BuildBetaDetailUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .buildBetaDetails, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BuildBetaGroupsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BuildBetaGroupsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct BuildBetaGroupsLinkagesRequest: Codable, Equatable {
             case betaGroups
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .betaGroups, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/BuildBetaNotification.swift
+++ b/Sources/_Specification/Generated/Entities/BuildBetaNotification.swift
@@ -14,7 +14,7 @@ public struct BuildBetaNotification: Codable, Equatable, Identifiable {
         case buildBetaNotifications
     }
 
-    public init(type: `Type`, id: String, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .buildBetaNotifications, id: String, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.links = links

--- a/Sources/_Specification/Generated/Entities/BuildBetaNotificationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BuildBetaNotificationCreateRequest.swift
@@ -30,7 +30,7 @@ public struct BuildBetaNotificationCreateRequest: Codable, Equatable {
                         case builds
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .builds, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -46,7 +46,7 @@ public struct BuildBetaNotificationCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .buildBetaNotifications, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/BuildBundle.swift
+++ b/Sources/_Specification/Generated/Entities/BuildBundle.swift
@@ -114,7 +114,7 @@ public struct BuildBundle: Codable, Equatable, Identifiable {
                     case appClipDomainStatuses
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appClipDomainStatuses, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -153,7 +153,7 @@ public struct BuildBundle: Codable, Equatable, Identifiable {
                     case appClipDomainStatuses
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appClipDomainStatuses, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -193,7 +193,7 @@ public struct BuildBundle: Codable, Equatable, Identifiable {
                     case betaAppClipInvocations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .betaAppClipInvocations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -234,7 +234,7 @@ public struct BuildBundle: Codable, Equatable, Identifiable {
                     case buildBundleFileSizes
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .buildBundleFileSizes, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -255,7 +255,7 @@ public struct BuildBundle: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .buildBundles, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BuildBundleFileSize.swift
+++ b/Sources/_Specification/Generated/Entities/BuildBundleFileSize.swift
@@ -29,7 +29,7 @@ public struct BuildBundleFileSize: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .buildBundleFileSizes, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BuildIcon.swift
+++ b/Sources/_Specification/Generated/Entities/BuildIcon.swift
@@ -27,7 +27,7 @@ public struct BuildIcon: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .buildIcons, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BuildIndividualTestersLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BuildIndividualTestersLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct BuildIndividualTestersLinkagesRequest: Codable, Equatable {
             case betaTesters
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .betaTesters, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/BuildIndividualTestersLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/BuildIndividualTestersLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct BuildIndividualTestersLinkagesResponse: Codable, Equatable {
             case betaTesters
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .betaTesters, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/BuildUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BuildUpdateRequest.swift
@@ -47,7 +47,7 @@ public struct BuildUpdateRequest: Codable, Equatable {
                         case appEncryptionDeclarations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appEncryptionDeclarations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -63,7 +63,7 @@ public struct BuildUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
+        public init(type: `Type` = .builds, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BundleID.swift
+++ b/Sources/_Specification/Generated/Entities/BundleID.swift
@@ -70,7 +70,7 @@ public struct BundleID: Codable, Equatable, Identifiable {
                     case profiles
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .profiles, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -111,7 +111,7 @@ public struct BundleID: Codable, Equatable, Identifiable {
                     case bundleIDCapabilities = "bundleIdCapabilities"
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .bundleIDCapabilities, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -151,7 +151,7 @@ public struct BundleID: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -176,7 +176,7 @@ public struct BundleID: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .bundleIDs, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BundleIDCapability.swift
+++ b/Sources/_Specification/Generated/Entities/BundleIDCapability.swift
@@ -25,7 +25,7 @@ public struct BundleIDCapability: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .bundleIDCapabilities, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BundleIDCapabilityCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BundleIDCapabilityCreateRequest.swift
@@ -41,7 +41,7 @@ public struct BundleIDCapabilityCreateRequest: Codable, Equatable {
                         case bundleIDs = "bundleIds"
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .bundleIDs, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -61,7 +61,7 @@ public struct BundleIDCapabilityCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .bundleIDCapabilities, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/BundleIDCapabilityUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BundleIDCapabilityUpdateRequest.swift
@@ -27,7 +27,7 @@ public struct BundleIDCapabilityUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .bundleIDCapabilities, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/BundleIDCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BundleIDCreateRequest.swift
@@ -37,7 +37,7 @@ public struct BundleIDCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes) {
+        public init(type: `Type` = .bundleIDs, attributes: Attributes) {
             self.type = type
             self.attributes = attributes
         }

--- a/Sources/_Specification/Generated/Entities/BundleIDUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/BundleIDUpdateRequest.swift
@@ -25,7 +25,7 @@ public struct BundleIDUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .bundleIDs, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/Certificate.swift
+++ b/Sources/_Specification/Generated/Entities/Certificate.swift
@@ -35,7 +35,7 @@ public struct Certificate: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .certificates, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/CertificateCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/CertificateCreateRequest.swift
@@ -26,7 +26,7 @@ public struct CertificateCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes) {
+        public init(type: `Type` = .certificates, attributes: Attributes) {
             self.type = type
             self.attributes = attributes
         }

--- a/Sources/_Specification/Generated/Entities/CiArtifact.swift
+++ b/Sources/_Specification/Generated/Entities/CiArtifact.swift
@@ -46,7 +46,7 @@ public struct CiArtifact: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .ciArtifacts, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/CiBuildAction.swift
+++ b/Sources/_Specification/Generated/Entities/CiBuildAction.swift
@@ -68,7 +68,7 @@ public struct CiBuildAction: Codable, Equatable, Identifiable {
                     case ciBuildRuns
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .ciBuildRuns, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -85,7 +85,7 @@ public struct CiBuildAction: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .ciBuildActions, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/CiBuildRun.swift
+++ b/Sources/_Specification/Generated/Entities/CiBuildRun.swift
@@ -144,7 +144,7 @@ public struct CiBuildRun: Codable, Equatable, Identifiable {
                     case builds
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .builds, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -184,7 +184,7 @@ public struct CiBuildRun: Codable, Equatable, Identifiable {
                     case ciWorkflows
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .ciWorkflows, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -223,7 +223,7 @@ public struct CiBuildRun: Codable, Equatable, Identifiable {
                     case ciProducts
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .ciProducts, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -262,7 +262,7 @@ public struct CiBuildRun: Codable, Equatable, Identifiable {
                     case scmGitReferences
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .scmGitReferences, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -301,7 +301,7 @@ public struct CiBuildRun: Codable, Equatable, Identifiable {
                     case scmGitReferences
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .scmGitReferences, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -340,7 +340,7 @@ public struct CiBuildRun: Codable, Equatable, Identifiable {
                     case scmPullRequests
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .scmPullRequests, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -362,7 +362,7 @@ public struct CiBuildRun: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .ciBuildRuns, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/CiBuildRunCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/CiBuildRunCreateRequest.swift
@@ -46,7 +46,7 @@ public struct CiBuildRunCreateRequest: Codable, Equatable {
                         case ciBuildRuns
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .ciBuildRuns, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -68,7 +68,7 @@ public struct CiBuildRunCreateRequest: Codable, Equatable {
                         case ciWorkflows
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .ciWorkflows, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -90,7 +90,7 @@ public struct CiBuildRunCreateRequest: Codable, Equatable {
                         case scmGitReferences
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .scmGitReferences, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -112,7 +112,7 @@ public struct CiBuildRunCreateRequest: Codable, Equatable {
                         case scmPullRequests
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .scmPullRequests, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -131,7 +131,7 @@ public struct CiBuildRunCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes? = nil, relationships: Relationships? = nil) {
+        public init(type: `Type` = .ciBuildRuns, attributes: Attributes? = nil, relationships: Relationships? = nil) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/CiIssue.swift
+++ b/Sources/_Specification/Generated/Entities/CiIssue.swift
@@ -36,7 +36,7 @@ public struct CiIssue: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .ciIssues, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/CiMacOsVersion.swift
+++ b/Sources/_Specification/Generated/Entities/CiMacOsVersion.swift
@@ -57,7 +57,7 @@ public struct CiMacOsVersion: Codable, Equatable, Identifiable {
                     case ciXcodeVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .ciXcodeVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -75,7 +75,7 @@ public struct CiMacOsVersion: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .ciMacOsVersions, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/CiProduct.swift
+++ b/Sources/_Specification/Generated/Entities/CiProduct.swift
@@ -65,7 +65,7 @@ public struct CiProduct: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -104,7 +104,7 @@ public struct CiProduct: Codable, Equatable, Identifiable {
                     case bundleIDs = "bundleIds"
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .bundleIDs, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -144,7 +144,7 @@ public struct CiProduct: Codable, Equatable, Identifiable {
                     case scmRepositories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .scmRepositories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -170,7 +170,7 @@ public struct CiProduct: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .ciProducts, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/CiTestResult.swift
+++ b/Sources/_Specification/Generated/Entities/CiTestResult.swift
@@ -49,7 +49,7 @@ public struct CiTestResult: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .ciTestResults, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/CiWorkflow.swift
+++ b/Sources/_Specification/Generated/Entities/CiWorkflow.swift
@@ -103,7 +103,7 @@ public struct CiWorkflow: Codable, Equatable, Identifiable {
                     case ciProducts
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .ciProducts, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -142,7 +142,7 @@ public struct CiWorkflow: Codable, Equatable, Identifiable {
                     case scmRepositories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .scmRepositories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -181,7 +181,7 @@ public struct CiWorkflow: Codable, Equatable, Identifiable {
                     case ciXcodeVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .ciXcodeVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -220,7 +220,7 @@ public struct CiWorkflow: Codable, Equatable, Identifiable {
                     case ciMacOsVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .ciMacOsVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -240,7 +240,7 @@ public struct CiWorkflow: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .ciWorkflows, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/CiWorkflowCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/CiWorkflowCreateRequest.swift
@@ -85,7 +85,7 @@ public struct CiWorkflowCreateRequest: Codable, Equatable {
                         case ciProducts
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .ciProducts, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -107,7 +107,7 @@ public struct CiWorkflowCreateRequest: Codable, Equatable {
                         case scmRepositories
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .scmRepositories, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -129,7 +129,7 @@ public struct CiWorkflowCreateRequest: Codable, Equatable {
                         case ciXcodeVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .ciXcodeVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -151,7 +151,7 @@ public struct CiWorkflowCreateRequest: Codable, Equatable {
                         case ciMacOsVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .ciMacOsVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -170,7 +170,7 @@ public struct CiWorkflowCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .ciWorkflows, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/CiWorkflowUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/CiWorkflowUpdateRequest.swift
@@ -84,7 +84,7 @@ public struct CiWorkflowUpdateRequest: Codable, Equatable {
                         case ciXcodeVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .ciXcodeVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -106,7 +106,7 @@ public struct CiWorkflowUpdateRequest: Codable, Equatable {
                         case ciMacOsVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .ciMacOsVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -123,7 +123,7 @@ public struct CiWorkflowUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
+        public init(type: `Type` = .ciWorkflows, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/CiXcodeVersion.swift
+++ b/Sources/_Specification/Generated/Entities/CiXcodeVersion.swift
@@ -83,7 +83,7 @@ public struct CiXcodeVersion: Codable, Equatable, Identifiable {
                     case ciMacOsVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .ciMacOsVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -101,7 +101,7 @@ public struct CiXcodeVersion: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .ciXcodeVersions, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/CustomerReview.swift
+++ b/Sources/_Specification/Generated/Entities/CustomerReview.swift
@@ -64,7 +64,7 @@ public struct CustomerReview: Codable, Equatable, Identifiable {
                     case customerReviewResponses
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .customerReviewResponses, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -81,7 +81,7 @@ public struct CustomerReview: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .customerReviews, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/CustomerReviewResponseV1.swift
+++ b/Sources/_Specification/Generated/Entities/CustomerReviewResponseV1.swift
@@ -63,7 +63,7 @@ public struct CustomerReviewResponseV1: Codable, Equatable, Identifiable {
                     case customerReviews
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .customerReviews, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -80,7 +80,7 @@ public struct CustomerReviewResponseV1: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .customerReviewResponses, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/CustomerReviewResponseV1CreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/CustomerReviewResponseV1CreateRequest.swift
@@ -39,7 +39,7 @@ public struct CustomerReviewResponseV1CreateRequest: Codable, Equatable {
                         case customerReviews
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .customerReviews, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -55,7 +55,7 @@ public struct CustomerReviewResponseV1CreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .customerReviewResponses, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/Device.swift
+++ b/Sources/_Specification/Generated/Entities/Device.swift
@@ -49,7 +49,7 @@ public struct Device: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .devices, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/DeviceCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/DeviceCreateRequest.swift
@@ -28,7 +28,7 @@ public struct DeviceCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes) {
+        public init(type: `Type` = .devices, attributes: Attributes) {
             self.type = type
             self.attributes = attributes
         }

--- a/Sources/_Specification/Generated/Entities/DeviceUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/DeviceUpdateRequest.swift
@@ -32,7 +32,7 @@ public struct DeviceUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .devices, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/DiagnosticLog.swift
+++ b/Sources/_Specification/Generated/Entities/DiagnosticLog.swift
@@ -14,7 +14,7 @@ public struct DiagnosticLog: Codable, Equatable, Identifiable {
         case diagnosticLogs
     }
 
-    public init(type: `Type`, id: String, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .diagnosticLogs, id: String, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.links = links

--- a/Sources/_Specification/Generated/Entities/DiagnosticSignature.swift
+++ b/Sources/_Specification/Generated/Entities/DiagnosticSignature.swift
@@ -32,7 +32,7 @@ public struct DiagnosticSignature: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .diagnosticSignatures, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/EndAppAvailabilityPreOrder.swift
+++ b/Sources/_Specification/Generated/Entities/EndAppAvailabilityPreOrder.swift
@@ -14,7 +14,7 @@ public struct EndAppAvailabilityPreOrder: Codable, Equatable, Identifiable {
         case endAppAvailabilityPreOrders
     }
 
-    public init(type: `Type`, id: String, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .endAppAvailabilityPreOrders, id: String, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.links = links

--- a/Sources/_Specification/Generated/Entities/EndAppAvailabilityPreOrderCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/EndAppAvailabilityPreOrderCreateRequest.swift
@@ -30,7 +30,7 @@ public struct EndAppAvailabilityPreOrderCreateRequest: Codable, Equatable {
                         case territoryAvailabilities
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .territoryAvailabilities, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -46,7 +46,7 @@ public struct EndAppAvailabilityPreOrderCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .endAppAvailabilityPreOrders, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/EndUserLicenseAgreement.swift
+++ b/Sources/_Specification/Generated/Entities/EndUserLicenseAgreement.swift
@@ -55,7 +55,7 @@ public struct EndUserLicenseAgreement: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -95,7 +95,7 @@ public struct EndUserLicenseAgreement: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -114,7 +114,7 @@ public struct EndUserLicenseAgreement: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .endUserLicenseAgreements, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/EndUserLicenseAgreementCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/EndUserLicenseAgreementCreateRequest.swift
@@ -40,7 +40,7 @@ public struct EndUserLicenseAgreementCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -62,7 +62,7 @@ public struct EndUserLicenseAgreementCreateRequest: Codable, Equatable {
                         case territories
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .territories, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -79,7 +79,7 @@ public struct EndUserLicenseAgreementCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .endUserLicenseAgreements, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/EndUserLicenseAgreementUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/EndUserLicenseAgreementUpdateRequest.swift
@@ -40,7 +40,7 @@ public struct EndUserLicenseAgreementUpdateRequest: Codable, Equatable {
                         case territories
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .territories, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -56,7 +56,7 @@ public struct EndUserLicenseAgreementUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
+        public init(type: `Type` = .endUserLicenseAgreements, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterAchievement.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAchievement.swift
@@ -77,7 +77,7 @@ public struct GameCenterAchievement: Codable, Equatable, Identifiable {
                     case gameCenterDetails
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterDetails, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -116,7 +116,7 @@ public struct GameCenterAchievement: Codable, Equatable, Identifiable {
                     case gameCenterGroups
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterGroups, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -155,7 +155,7 @@ public struct GameCenterAchievement: Codable, Equatable, Identifiable {
                     case gameCenterAchievements
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterAchievements, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -195,7 +195,7 @@ public struct GameCenterAchievement: Codable, Equatable, Identifiable {
                     case gameCenterAchievementLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterAchievementLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -236,7 +236,7 @@ public struct GameCenterAchievement: Codable, Equatable, Identifiable {
                     case gameCenterAchievementReleases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterAchievementReleases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -258,7 +258,7 @@ public struct GameCenterAchievement: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterAchievements, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterAchievementCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAchievementCreateRequest.swift
@@ -56,7 +56,7 @@ public struct GameCenterAchievementCreateRequest: Codable, Equatable {
                         case gameCenterDetails
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterDetails, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -78,7 +78,7 @@ public struct GameCenterAchievementCreateRequest: Codable, Equatable {
                         case gameCenterGroups
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterGroups, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -95,7 +95,7 @@ public struct GameCenterAchievementCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships? = nil) {
+        public init(type: `Type` = .gameCenterAchievements, attributes: Attributes, relationships: Relationships? = nil) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/GameCenterAchievementGroupAchievementLinkageRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAchievementGroupAchievementLinkageRequest.swift
@@ -16,7 +16,7 @@ public struct GameCenterAchievementGroupAchievementLinkageRequest: Codable, Equa
             case gameCenterAchievements
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterAchievements, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterAchievementGroupAchievementLinkageResponse.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAchievementGroupAchievementLinkageResponse.swift
@@ -17,7 +17,7 @@ public struct GameCenterAchievementGroupAchievementLinkageResponse: Codable, Equ
             case gameCenterAchievements
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterAchievements, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterAchievementImage.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAchievementImage.swift
@@ -62,7 +62,7 @@ public struct GameCenterAchievementImage: Codable, Equatable, Identifiable {
                     case gameCenterAchievementLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterAchievementLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -79,7 +79,7 @@ public struct GameCenterAchievementImage: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterAchievementImages, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterAchievementImageCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAchievementImageCreateRequest.swift
@@ -41,7 +41,7 @@ public struct GameCenterAchievementImageCreateRequest: Codable, Equatable {
                         case gameCenterAchievementLocalizations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterAchievementLocalizations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct GameCenterAchievementImageCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .gameCenterAchievementImages, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/GameCenterAchievementImageUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAchievementImageUpdateRequest.swift
@@ -29,7 +29,7 @@ public struct GameCenterAchievementImageUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .gameCenterAchievementImages, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterAchievementLocalization.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAchievementLocalization.swift
@@ -61,7 +61,7 @@ public struct GameCenterAchievementLocalization: Codable, Equatable, Identifiabl
                     case gameCenterAchievements
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterAchievements, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -100,7 +100,7 @@ public struct GameCenterAchievementLocalization: Codable, Equatable, Identifiabl
                     case gameCenterAchievementImages
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterAchievementImages, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -118,7 +118,7 @@ public struct GameCenterAchievementLocalization: Codable, Equatable, Identifiabl
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterAchievementLocalizations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterAchievementLocalizationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAchievementLocalizationCreateRequest.swift
@@ -45,7 +45,7 @@ public struct GameCenterAchievementLocalizationCreateRequest: Codable, Equatable
                         case gameCenterAchievements
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterAchievements, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -61,7 +61,7 @@ public struct GameCenterAchievementLocalizationCreateRequest: Codable, Equatable
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .gameCenterAchievementLocalizations, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/GameCenterAchievementLocalizationUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAchievementLocalizationUpdateRequest.swift
@@ -29,7 +29,7 @@ public struct GameCenterAchievementLocalizationUpdateRequest: Codable, Equatable
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .gameCenterAchievementLocalizations, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterAchievementRelease.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAchievementRelease.swift
@@ -59,7 +59,7 @@ public struct GameCenterAchievementRelease: Codable, Equatable, Identifiable {
                     case gameCenterDetails
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterDetails, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -98,7 +98,7 @@ public struct GameCenterAchievementRelease: Codable, Equatable, Identifiable {
                     case gameCenterAchievements
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterAchievements, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -116,7 +116,7 @@ public struct GameCenterAchievementRelease: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterAchievementReleases, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterAchievementReleaseCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAchievementReleaseCreateRequest.swift
@@ -31,7 +31,7 @@ public struct GameCenterAchievementReleaseCreateRequest: Codable, Equatable {
                         case gameCenterDetails
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterDetails, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -53,7 +53,7 @@ public struct GameCenterAchievementReleaseCreateRequest: Codable, Equatable {
                         case gameCenterAchievements
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterAchievements, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -70,7 +70,7 @@ public struct GameCenterAchievementReleaseCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .gameCenterAchievementReleases, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterAchievementUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAchievementUpdateRequest.swift
@@ -41,7 +41,7 @@ public struct GameCenterAchievementUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .gameCenterAchievements, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterAppVersion.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAppVersion.swift
@@ -60,7 +60,7 @@ public struct GameCenterAppVersion: Codable, Equatable, Identifiable {
                     case gameCenterAppVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterAppVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -100,7 +100,7 @@ public struct GameCenterAppVersion: Codable, Equatable, Identifiable {
                     case appStoreVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -118,7 +118,7 @@ public struct GameCenterAppVersion: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterAppVersions, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterAppVersionCompatibilityVersionsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAppVersionCompatibilityVersionsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct GameCenterAppVersionCompatibilityVersionsLinkagesRequest: Codable,
             case gameCenterAppVersions
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterAppVersions, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterAppVersionCompatibilityVersionsLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAppVersionCompatibilityVersionsLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct GameCenterAppVersionCompatibilityVersionsLinkagesResponse: Codable
             case gameCenterAppVersions
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterAppVersions, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterAppVersionCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAppVersionCreateRequest.swift
@@ -30,7 +30,7 @@ public struct GameCenterAppVersionCreateRequest: Codable, Equatable {
                         case appStoreVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -46,7 +46,7 @@ public struct GameCenterAppVersionCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .gameCenterAppVersions, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterAppVersionUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterAppVersionUpdateRequest.swift
@@ -29,7 +29,7 @@ public struct GameCenterAppVersionUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .gameCenterAppVersions, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterDetail.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterDetail.swift
@@ -71,7 +71,7 @@ public struct GameCenterDetail: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -111,7 +111,7 @@ public struct GameCenterDetail: Codable, Equatable, Identifiable {
                     case gameCenterAppVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterAppVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -151,7 +151,7 @@ public struct GameCenterDetail: Codable, Equatable, Identifiable {
                     case gameCenterGroups
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterGroups, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -191,7 +191,7 @@ public struct GameCenterDetail: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboards
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboards, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -232,7 +232,7 @@ public struct GameCenterDetail: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboardSets
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboardSets, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -273,7 +273,7 @@ public struct GameCenterDetail: Codable, Equatable, Identifiable {
                     case gameCenterAchievements
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterAchievements, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -313,7 +313,7 @@ public struct GameCenterDetail: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboards
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboards, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -352,7 +352,7 @@ public struct GameCenterDetail: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboards
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboards, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -392,7 +392,7 @@ public struct GameCenterDetail: Codable, Equatable, Identifiable {
                     case gameCenterAchievementReleases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterAchievementReleases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -433,7 +433,7 @@ public struct GameCenterDetail: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboardReleases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboardReleases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -474,7 +474,7 @@ public struct GameCenterDetail: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboardSetReleases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboardSetReleases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -502,7 +502,7 @@ public struct GameCenterDetail: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterDetails, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterDetailCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterDetailCreateRequest.swift
@@ -43,7 +43,7 @@ public struct GameCenterDetailCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -59,7 +59,7 @@ public struct GameCenterDetailCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes? = nil, relationships: Relationships) {
+        public init(type: `Type` = .gameCenterDetails, attributes: Attributes? = nil, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/GameCenterDetailGameCenterAchievementsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterDetailGameCenterAchievementsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct GameCenterDetailGameCenterAchievementsLinkagesRequest: Codable, Eq
             case gameCenterAchievements
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterAchievements, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterDetailGameCenterAchievementsLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterDetailGameCenterAchievementsLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct GameCenterDetailGameCenterAchievementsLinkagesResponse: Codable, E
             case gameCenterAchievements
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterAchievements, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterDetailGameCenterLeaderboardSetsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterDetailGameCenterLeaderboardSetsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct GameCenterDetailGameCenterLeaderboardSetsLinkagesRequest: Codable,
             case gameCenterLeaderboardSets
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterLeaderboardSets, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterDetailGameCenterLeaderboardSetsLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterDetailGameCenterLeaderboardSetsLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct GameCenterDetailGameCenterLeaderboardSetsLinkagesResponse: Codable
             case gameCenterLeaderboardSets
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterLeaderboardSets, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterDetailGameCenterLeaderboardsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterDetailGameCenterLeaderboardsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct GameCenterDetailGameCenterLeaderboardsLinkagesRequest: Codable, Eq
             case gameCenterLeaderboards
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterLeaderboards, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterDetailGameCenterLeaderboardsLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterDetailGameCenterLeaderboardsLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct GameCenterDetailGameCenterLeaderboardsLinkagesResponse: Codable, E
             case gameCenterLeaderboards
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterLeaderboards, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterDetailUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterDetailUpdateRequest.swift
@@ -46,7 +46,7 @@ public struct GameCenterDetailUpdateRequest: Codable, Equatable {
                         case gameCenterGroups
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterGroups, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -68,7 +68,7 @@ public struct GameCenterDetailUpdateRequest: Codable, Equatable {
                         case gameCenterLeaderboards
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterLeaderboards, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -90,7 +90,7 @@ public struct GameCenterDetailUpdateRequest: Codable, Equatable {
                         case gameCenterLeaderboards
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterLeaderboards, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -108,7 +108,7 @@ public struct GameCenterDetailUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
+        public init(type: `Type` = .gameCenterDetails, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterEnabledVersion.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterEnabledVersion.swift
@@ -60,7 +60,7 @@ public struct GameCenterEnabledVersion: Codable, Equatable, Identifiable {
                     case gameCenterEnabledVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterEnabledVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -100,7 +100,7 @@ public struct GameCenterEnabledVersion: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -118,7 +118,7 @@ public struct GameCenterEnabledVersion: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterEnabledVersions, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterEnabledVersionCompatibleVersionsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterEnabledVersionCompatibleVersionsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct GameCenterEnabledVersionCompatibleVersionsLinkagesRequest: Codable
             case gameCenterEnabledVersions
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterEnabledVersions, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterEnabledVersionCompatibleVersionsLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterEnabledVersionCompatibleVersionsLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct GameCenterEnabledVersionCompatibleVersionsLinkagesResponse: Codabl
             case gameCenterEnabledVersions
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterEnabledVersions, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterGroup.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterGroup.swift
@@ -58,7 +58,7 @@ public struct GameCenterGroup: Codable, Equatable, Identifiable {
                     case gameCenterDetails
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterDetails, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -99,7 +99,7 @@ public struct GameCenterGroup: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboards
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboards, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -140,7 +140,7 @@ public struct GameCenterGroup: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboardSets
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboardSets, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -181,7 +181,7 @@ public struct GameCenterGroup: Codable, Equatable, Identifiable {
                     case gameCenterAchievements
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterAchievements, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -202,7 +202,7 @@ public struct GameCenterGroup: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterGroups, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterGroupCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterGroupCreateRequest.swift
@@ -24,7 +24,7 @@ public struct GameCenterGroupCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes? = nil) {
+        public init(type: `Type` = .gameCenterGroups, attributes: Attributes? = nil) {
             self.type = type
             self.attributes = attributes
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterGroupGameCenterAchievementsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterGroupGameCenterAchievementsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct GameCenterGroupGameCenterAchievementsLinkagesRequest: Codable, Equ
             case gameCenterAchievements
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterAchievements, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterGroupGameCenterAchievementsLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterGroupGameCenterAchievementsLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct GameCenterGroupGameCenterAchievementsLinkagesResponse: Codable, Eq
             case gameCenterAchievements
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterAchievements, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterGroupGameCenterLeaderboardSetsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterGroupGameCenterLeaderboardSetsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct GameCenterGroupGameCenterLeaderboardSetsLinkagesRequest: Codable, 
             case gameCenterLeaderboardSets
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterLeaderboardSets, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterGroupGameCenterLeaderboardSetsLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterGroupGameCenterLeaderboardSetsLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct GameCenterGroupGameCenterLeaderboardSetsLinkagesResponse: Codable,
             case gameCenterLeaderboardSets
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterLeaderboardSets, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterGroupGameCenterLeaderboardsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterGroupGameCenterLeaderboardsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct GameCenterGroupGameCenterLeaderboardsLinkagesRequest: Codable, Equ
             case gameCenterLeaderboards
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterLeaderboards, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterGroupGameCenterLeaderboardsLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterGroupGameCenterLeaderboardsLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct GameCenterGroupGameCenterLeaderboardsLinkagesResponse: Codable, Eq
             case gameCenterLeaderboards
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterLeaderboards, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterGroupUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterGroupUpdateRequest.swift
@@ -25,7 +25,7 @@ public struct GameCenterGroupUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .gameCenterGroups, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboard.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboard.swift
@@ -103,7 +103,7 @@ public struct GameCenterLeaderboard: Codable, Equatable, Identifiable {
                     case gameCenterDetails
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterDetails, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -142,7 +142,7 @@ public struct GameCenterLeaderboard: Codable, Equatable, Identifiable {
                     case gameCenterGroups
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterGroups, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -181,7 +181,7 @@ public struct GameCenterLeaderboard: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboards
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboards, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -221,7 +221,7 @@ public struct GameCenterLeaderboard: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboardSets
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboardSets, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -262,7 +262,7 @@ public struct GameCenterLeaderboard: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboardLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboardLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -303,7 +303,7 @@ public struct GameCenterLeaderboard: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboardReleases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboardReleases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -326,7 +326,7 @@ public struct GameCenterLeaderboard: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterLeaderboards, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardCreateRequest.swift
@@ -69,7 +69,7 @@ public struct GameCenterLeaderboardCreateRequest: Codable, Equatable {
                         case gameCenterDetails
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterDetails, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -91,7 +91,7 @@ public struct GameCenterLeaderboardCreateRequest: Codable, Equatable {
                         case gameCenterGroups
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterGroups, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -113,7 +113,7 @@ public struct GameCenterLeaderboardCreateRequest: Codable, Equatable {
                         case gameCenterLeaderboardSets
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterLeaderboardSets, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -131,7 +131,7 @@ public struct GameCenterLeaderboardCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships? = nil) {
+        public init(type: `Type` = .gameCenterLeaderboards, attributes: Attributes, relationships: Relationships? = nil) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardEntrySubmission.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardEntrySubmission.swift
@@ -45,7 +45,7 @@ public struct GameCenterLeaderboardEntrySubmission: Codable, Equatable, Identifi
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterLeaderboardEntrySubmissions, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardEntrySubmissionCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardEntrySubmissionCreateRequest.swift
@@ -46,7 +46,7 @@ public struct GameCenterLeaderboardEntrySubmissionCreateRequest: Codable, Equata
             }
         }
 
-        public init(type: `Type`, attributes: Attributes) {
+        public init(type: `Type` = .gameCenterLeaderboardEntrySubmissions, attributes: Attributes) {
             self.type = type
             self.attributes = attributes
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardGroupLeaderboardLinkageRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardGroupLeaderboardLinkageRequest.swift
@@ -16,7 +16,7 @@ public struct GameCenterLeaderboardGroupLeaderboardLinkageRequest: Codable, Equa
             case gameCenterLeaderboards
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterLeaderboards, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardGroupLeaderboardLinkageResponse.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardGroupLeaderboardLinkageResponse.swift
@@ -17,7 +17,7 @@ public struct GameCenterLeaderboardGroupLeaderboardLinkageResponse: Codable, Equ
             case gameCenterLeaderboards
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterLeaderboards, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardImage.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardImage.swift
@@ -62,7 +62,7 @@ public struct GameCenterLeaderboardImage: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboardLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboardLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -79,7 +79,7 @@ public struct GameCenterLeaderboardImage: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterLeaderboardImages, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardImageCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardImageCreateRequest.swift
@@ -41,7 +41,7 @@ public struct GameCenterLeaderboardImageCreateRequest: Codable, Equatable {
                         case gameCenterLeaderboardLocalizations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterLeaderboardLocalizations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct GameCenterLeaderboardImageCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .gameCenterLeaderboardImages, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardImageUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardImageUpdateRequest.swift
@@ -29,7 +29,7 @@ public struct GameCenterLeaderboardImageUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .gameCenterLeaderboardImages, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardLocalization.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardLocalization.swift
@@ -63,7 +63,7 @@ public struct GameCenterLeaderboardLocalization: Codable, Equatable, Identifiabl
                     case gameCenterLeaderboards
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboards, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -102,7 +102,7 @@ public struct GameCenterLeaderboardLocalization: Codable, Equatable, Identifiabl
                     case gameCenterLeaderboardImages
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboardImages, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -120,7 +120,7 @@ public struct GameCenterLeaderboardLocalization: Codable, Equatable, Identifiabl
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterLeaderboardLocalizations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardLocalizationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardLocalizationCreateRequest.swift
@@ -47,7 +47,7 @@ public struct GameCenterLeaderboardLocalizationCreateRequest: Codable, Equatable
                         case gameCenterLeaderboards
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterLeaderboards, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -63,7 +63,7 @@ public struct GameCenterLeaderboardLocalizationCreateRequest: Codable, Equatable
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .gameCenterLeaderboardLocalizations, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardLocalizationUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardLocalizationUpdateRequest.swift
@@ -31,7 +31,7 @@ public struct GameCenterLeaderboardLocalizationUpdateRequest: Codable, Equatable
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .gameCenterLeaderboardLocalizations, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardRelease.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardRelease.swift
@@ -59,7 +59,7 @@ public struct GameCenterLeaderboardRelease: Codable, Equatable, Identifiable {
                     case gameCenterDetails
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterDetails, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -98,7 +98,7 @@ public struct GameCenterLeaderboardRelease: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboards
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboards, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -116,7 +116,7 @@ public struct GameCenterLeaderboardRelease: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterLeaderboardReleases, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardReleaseCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardReleaseCreateRequest.swift
@@ -31,7 +31,7 @@ public struct GameCenterLeaderboardReleaseCreateRequest: Codable, Equatable {
                         case gameCenterDetails
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterDetails, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -53,7 +53,7 @@ public struct GameCenterLeaderboardReleaseCreateRequest: Codable, Equatable {
                         case gameCenterLeaderboards
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterLeaderboards, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -70,7 +70,7 @@ public struct GameCenterLeaderboardReleaseCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .gameCenterLeaderboardReleases, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSet.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSet.swift
@@ -61,7 +61,7 @@ public struct GameCenterLeaderboardSet: Codable, Equatable, Identifiable {
                     case gameCenterDetails
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterDetails, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -100,7 +100,7 @@ public struct GameCenterLeaderboardSet: Codable, Equatable, Identifiable {
                     case gameCenterGroups
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterGroups, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -139,7 +139,7 @@ public struct GameCenterLeaderboardSet: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboardSets
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboardSets, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -179,7 +179,7 @@ public struct GameCenterLeaderboardSet: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboardSetLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboardSetLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -220,7 +220,7 @@ public struct GameCenterLeaderboardSet: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboards
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboards, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -261,7 +261,7 @@ public struct GameCenterLeaderboardSet: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboardSetReleases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboardSetReleases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -284,7 +284,7 @@ public struct GameCenterLeaderboardSet: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterLeaderboardSets, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetCreateRequest.swift
@@ -43,7 +43,7 @@ public struct GameCenterLeaderboardSetCreateRequest: Codable, Equatable {
                         case gameCenterDetails
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterDetails, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -65,7 +65,7 @@ public struct GameCenterLeaderboardSetCreateRequest: Codable, Equatable {
                         case gameCenterGroups
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterGroups, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -87,7 +87,7 @@ public struct GameCenterLeaderboardSetCreateRequest: Codable, Equatable {
                         case gameCenterLeaderboards
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterLeaderboards, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -105,7 +105,7 @@ public struct GameCenterLeaderboardSetCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships? = nil) {
+        public init(type: `Type` = .gameCenterLeaderboardSets, attributes: Attributes, relationships: Relationships? = nil) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetGameCenterLeaderboardsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetGameCenterLeaderboardsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct GameCenterLeaderboardSetGameCenterLeaderboardsLinkagesRequest: Cod
             case gameCenterLeaderboards
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterLeaderboards, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetGameCenterLeaderboardsLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetGameCenterLeaderboardsLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct GameCenterLeaderboardSetGameCenterLeaderboardsLinkagesResponse: Co
             case gameCenterLeaderboards
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterLeaderboards, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetGroupLeaderboardSetLinkageRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetGroupLeaderboardSetLinkageRequest.swift
@@ -16,7 +16,7 @@ public struct GameCenterLeaderboardSetGroupLeaderboardSetLinkageRequest: Codable
             case gameCenterLeaderboardSets
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterLeaderboardSets, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetGroupLeaderboardSetLinkageResponse.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetGroupLeaderboardSetLinkageResponse.swift
@@ -17,7 +17,7 @@ public struct GameCenterLeaderboardSetGroupLeaderboardSetLinkageResponse: Codabl
             case gameCenterLeaderboardSets
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .gameCenterLeaderboardSets, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetImage.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetImage.swift
@@ -62,7 +62,7 @@ public struct GameCenterLeaderboardSetImage: Codable, Equatable, Identifiable {
                     case gameCenterLeaderboardSetLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboardSetLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -79,7 +79,7 @@ public struct GameCenterLeaderboardSetImage: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterLeaderboardSetImages, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetImageCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetImageCreateRequest.swift
@@ -41,7 +41,7 @@ public struct GameCenterLeaderboardSetImageCreateRequest: Codable, Equatable {
                         case gameCenterLeaderboardSetLocalizations
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterLeaderboardSetLocalizations, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct GameCenterLeaderboardSetImageCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .gameCenterLeaderboardSetImages, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetImageUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetImageUpdateRequest.swift
@@ -29,7 +29,7 @@ public struct GameCenterLeaderboardSetImageUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .gameCenterLeaderboardSetImages, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetLocalization.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetLocalization.swift
@@ -57,7 +57,7 @@ public struct GameCenterLeaderboardSetLocalization: Codable, Equatable, Identifi
                     case gameCenterLeaderboardSets
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboardSets, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -96,7 +96,7 @@ public struct GameCenterLeaderboardSetLocalization: Codable, Equatable, Identifi
                     case gameCenterLeaderboardSetImages
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboardSetImages, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -114,7 +114,7 @@ public struct GameCenterLeaderboardSetLocalization: Codable, Equatable, Identifi
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterLeaderboardSetLocalizations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetLocalizationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetLocalizationCreateRequest.swift
@@ -41,7 +41,7 @@ public struct GameCenterLeaderboardSetLocalizationCreateRequest: Codable, Equata
                         case gameCenterLeaderboardSets
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterLeaderboardSets, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct GameCenterLeaderboardSetLocalizationCreateRequest: Codable, Equata
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .gameCenterLeaderboardSetLocalizations, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetLocalizationUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetLocalizationUpdateRequest.swift
@@ -25,7 +25,7 @@ public struct GameCenterLeaderboardSetLocalizationUpdateRequest: Codable, Equata
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .gameCenterLeaderboardSetLocalizations, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetMemberLocalization.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetMemberLocalization.swift
@@ -57,7 +57,7 @@ public struct GameCenterLeaderboardSetMemberLocalization: Codable, Equatable, Id
                     case gameCenterLeaderboardSets
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboardSets, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -96,7 +96,7 @@ public struct GameCenterLeaderboardSetMemberLocalization: Codable, Equatable, Id
                     case gameCenterLeaderboards
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboards, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -114,7 +114,7 @@ public struct GameCenterLeaderboardSetMemberLocalization: Codable, Equatable, Id
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterLeaderboardSetMemberLocalizations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetMemberLocalizationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetMemberLocalizationCreateRequest.swift
@@ -42,7 +42,7 @@ public struct GameCenterLeaderboardSetMemberLocalizationCreateRequest: Codable, 
                         case gameCenterLeaderboardSets
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterLeaderboardSets, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -64,7 +64,7 @@ public struct GameCenterLeaderboardSetMemberLocalizationCreateRequest: Codable, 
                         case gameCenterLeaderboards
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterLeaderboards, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -81,7 +81,7 @@ public struct GameCenterLeaderboardSetMemberLocalizationCreateRequest: Codable, 
             }
         }
 
-        public init(type: `Type`, attributes: Attributes? = nil, relationships: Relationships) {
+        public init(type: `Type` = .gameCenterLeaderboardSetMemberLocalizations, attributes: Attributes? = nil, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetMemberLocalizationUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetMemberLocalizationUpdateRequest.swift
@@ -25,7 +25,7 @@ public struct GameCenterLeaderboardSetMemberLocalizationUpdateRequest: Codable, 
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .gameCenterLeaderboardSetMemberLocalizations, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetRelease.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetRelease.swift
@@ -59,7 +59,7 @@ public struct GameCenterLeaderboardSetRelease: Codable, Equatable, Identifiable 
                     case gameCenterDetails
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterDetails, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -98,7 +98,7 @@ public struct GameCenterLeaderboardSetRelease: Codable, Equatable, Identifiable 
                     case gameCenterLeaderboardSets
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterLeaderboardSets, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -116,7 +116,7 @@ public struct GameCenterLeaderboardSetRelease: Codable, Equatable, Identifiable 
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterLeaderboardSetReleases, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetReleaseCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetReleaseCreateRequest.swift
@@ -31,7 +31,7 @@ public struct GameCenterLeaderboardSetReleaseCreateRequest: Codable, Equatable {
                         case gameCenterDetails
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterDetails, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -53,7 +53,7 @@ public struct GameCenterLeaderboardSetReleaseCreateRequest: Codable, Equatable {
                         case gameCenterLeaderboardSets
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterLeaderboardSets, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -70,7 +70,7 @@ public struct GameCenterLeaderboardSetReleaseCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .gameCenterLeaderboardSetReleases, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardSetUpdateRequest.swift
@@ -25,7 +25,7 @@ public struct GameCenterLeaderboardSetUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .gameCenterLeaderboardSets, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterLeaderboardUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterLeaderboardUpdateRequest.swift
@@ -66,7 +66,7 @@ public struct GameCenterLeaderboardUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .gameCenterLeaderboards, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterMatchmakingQueue.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterMatchmakingQueue.swift
@@ -62,7 +62,7 @@ public struct GameCenterMatchmakingQueue: Codable, Equatable, Identifiable {
                     case gameCenterMatchmakingRuleSets
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterMatchmakingRuleSets, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -101,7 +101,7 @@ public struct GameCenterMatchmakingQueue: Codable, Equatable, Identifiable {
                     case gameCenterMatchmakingRuleSets
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterMatchmakingRuleSets, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -119,7 +119,7 @@ public struct GameCenterMatchmakingQueue: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterMatchmakingQueues, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterMatchmakingQueueCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterMatchmakingQueueCreateRequest.swift
@@ -47,7 +47,7 @@ public struct GameCenterMatchmakingQueueCreateRequest: Codable, Equatable {
                         case gameCenterMatchmakingRuleSets
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterMatchmakingRuleSets, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -69,7 +69,7 @@ public struct GameCenterMatchmakingQueueCreateRequest: Codable, Equatable {
                         case gameCenterMatchmakingRuleSets
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterMatchmakingRuleSets, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -86,7 +86,7 @@ public struct GameCenterMatchmakingQueueCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .gameCenterMatchmakingQueues, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/GameCenterMatchmakingQueueUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterMatchmakingQueueUpdateRequest.swift
@@ -45,7 +45,7 @@ public struct GameCenterMatchmakingQueueUpdateRequest: Codable, Equatable {
                         case gameCenterMatchmakingRuleSets
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterMatchmakingRuleSets, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -67,7 +67,7 @@ public struct GameCenterMatchmakingQueueUpdateRequest: Codable, Equatable {
                         case gameCenterMatchmakingRuleSets
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterMatchmakingRuleSets, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -84,7 +84,7 @@ public struct GameCenterMatchmakingQueueUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
+        public init(type: `Type` = .gameCenterMatchmakingQueues, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterMatchmakingRule.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterMatchmakingRule.swift
@@ -38,7 +38,7 @@ public struct GameCenterMatchmakingRule: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterMatchmakingRules, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterMatchmakingRuleCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterMatchmakingRuleCreateRequest.swift
@@ -54,7 +54,7 @@ public struct GameCenterMatchmakingRuleCreateRequest: Codable, Equatable {
                         case gameCenterMatchmakingRuleSets
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterMatchmakingRuleSets, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -70,7 +70,7 @@ public struct GameCenterMatchmakingRuleCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .gameCenterMatchmakingRules, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/GameCenterMatchmakingRuleSet.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterMatchmakingRuleSet.swift
@@ -63,7 +63,7 @@ public struct GameCenterMatchmakingRuleSet: Codable, Equatable, Identifiable {
                     case gameCenterMatchmakingTeams
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterMatchmakingTeams, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -104,7 +104,7 @@ public struct GameCenterMatchmakingRuleSet: Codable, Equatable, Identifiable {
                     case gameCenterMatchmakingRules
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterMatchmakingRules, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -145,7 +145,7 @@ public struct GameCenterMatchmakingRuleSet: Codable, Equatable, Identifiable {
                     case gameCenterMatchmakingQueues
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterMatchmakingQueues, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -165,7 +165,7 @@ public struct GameCenterMatchmakingRuleSet: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterMatchmakingRuleSets, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterMatchmakingRuleSetCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterMatchmakingRuleSetCreateRequest.swift
@@ -30,7 +30,7 @@ public struct GameCenterMatchmakingRuleSetCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes) {
+        public init(type: `Type` = .gameCenterMatchmakingRuleSets, attributes: Attributes) {
             self.type = type
             self.attributes = attributes
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterMatchmakingRuleSetTest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterMatchmakingRuleSetTest.swift
@@ -33,7 +33,7 @@ public struct GameCenterMatchmakingRuleSetTest: Codable, Equatable, Identifiable
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterMatchmakingRuleSetTests, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterMatchmakingRuleSetTestCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterMatchmakingRuleSetTestCreateRequest.swift
@@ -32,7 +32,7 @@ public struct GameCenterMatchmakingRuleSetTestCreateRequest: Codable, Equatable 
                         case gameCenterMatchmakingRuleSets
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterMatchmakingRuleSets, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -54,7 +54,7 @@ public struct GameCenterMatchmakingRuleSetTestCreateRequest: Codable, Equatable 
                         case gameCenterMatchmakingTestRequests
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterMatchmakingTestRequests, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -71,7 +71,7 @@ public struct GameCenterMatchmakingRuleSetTestCreateRequest: Codable, Equatable 
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .gameCenterMatchmakingRuleSetTests, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/GameCenterMatchmakingRuleSetUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterMatchmakingRuleSetUpdateRequest.swift
@@ -27,7 +27,7 @@ public struct GameCenterMatchmakingRuleSetUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .gameCenterMatchmakingRuleSets, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterMatchmakingRuleUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterMatchmakingRuleUpdateRequest.swift
@@ -29,7 +29,7 @@ public struct GameCenterMatchmakingRuleUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .gameCenterMatchmakingRules, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterMatchmakingTeam.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterMatchmakingTeam.swift
@@ -27,7 +27,7 @@ public struct GameCenterMatchmakingTeam: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterMatchmakingTeams, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterMatchmakingTeamCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterMatchmakingTeamCreateRequest.swift
@@ -43,7 +43,7 @@ public struct GameCenterMatchmakingTeamCreateRequest: Codable, Equatable {
                         case gameCenterMatchmakingRuleSets
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .gameCenterMatchmakingRuleSets, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -59,7 +59,7 @@ public struct GameCenterMatchmakingTeamCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .gameCenterMatchmakingTeams, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/GameCenterMatchmakingTeamUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterMatchmakingTeamUpdateRequest.swift
@@ -27,7 +27,7 @@ public struct GameCenterMatchmakingTeamUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .gameCenterMatchmakingTeams, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterMatchmakingTestPlayerPropertyInlineCreate.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterMatchmakingTestPlayerPropertyInlineCreate.swift
@@ -29,7 +29,7 @@ public struct GameCenterMatchmakingTestPlayerPropertyInlineCreate: Codable, Equa
         }
     }
 
-    public init(type: `Type`, id: String? = nil, attributes: Attributes) {
+    public init(type: `Type` = .gameCenterMatchmakingTestPlayerProperties, id: String? = nil, attributes: Attributes) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterMatchmakingTestRequestInlineCreate.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterMatchmakingTestRequestInlineCreate.swift
@@ -110,7 +110,7 @@ public struct GameCenterMatchmakingTestRequestInlineCreate: Codable, Equatable, 
                     case gameCenterMatchmakingTestPlayerProperties
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .gameCenterMatchmakingTestPlayerProperties, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -126,7 +126,7 @@ public struct GameCenterMatchmakingTestRequestInlineCreate: Codable, Equatable, 
         }
     }
 
-    public init(type: `Type`, id: String? = nil, attributes: Attributes, relationships: Relationships? = nil) {
+    public init(type: `Type` = .gameCenterMatchmakingTestRequests, id: String? = nil, attributes: Attributes, relationships: Relationships? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterPlayerAchievementSubmission.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterPlayerAchievementSubmission.swift
@@ -42,7 +42,7 @@ public struct GameCenterPlayerAchievementSubmission: Codable, Equatable, Identif
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .gameCenterPlayerAchievementSubmissions, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/GameCenterPlayerAchievementSubmissionCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/GameCenterPlayerAchievementSubmissionCreateRequest.swift
@@ -43,7 +43,7 @@ public struct GameCenterPlayerAchievementSubmissionCreateRequest: Codable, Equat
             }
         }
 
-        public init(type: `Type`, attributes: Attributes) {
+        public init(type: `Type` = .gameCenterPlayerAchievementSubmissions, attributes: Attributes) {
             self.type = type
             self.attributes = attributes
         }

--- a/Sources/_Specification/Generated/Entities/InAppPurchase.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchase.swift
@@ -98,7 +98,7 @@ public struct InAppPurchase: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -116,7 +116,7 @@ public struct InAppPurchase: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .inAppPurchases, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/InAppPurchaseAppStoreReviewScreenshot.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchaseAppStoreReviewScreenshot.swift
@@ -68,7 +68,7 @@ public struct InAppPurchaseAppStoreReviewScreenshot: Codable, Equatable, Identif
                     case inAppPurchases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -85,7 +85,7 @@ public struct InAppPurchaseAppStoreReviewScreenshot: Codable, Equatable, Identif
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .inAppPurchaseAppStoreReviewScreenshots, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/InAppPurchaseAppStoreReviewScreenshotCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchaseAppStoreReviewScreenshotCreateRequest.swift
@@ -41,7 +41,7 @@ public struct InAppPurchaseAppStoreReviewScreenshotCreateRequest: Codable, Equat
                         case inAppPurchases
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .inAppPurchases, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct InAppPurchaseAppStoreReviewScreenshotCreateRequest: Codable, Equat
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .inAppPurchaseAppStoreReviewScreenshots, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/InAppPurchaseAppStoreReviewScreenshotUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchaseAppStoreReviewScreenshotUpdateRequest.swift
@@ -32,7 +32,7 @@ public struct InAppPurchaseAppStoreReviewScreenshotUpdateRequest: Codable, Equat
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .inAppPurchaseAppStoreReviewScreenshots, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/InAppPurchaseAvailability.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchaseAvailability.swift
@@ -59,7 +59,7 @@ public struct InAppPurchaseAvailability: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -77,7 +77,7 @@ public struct InAppPurchaseAvailability: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .inAppPurchaseAvailabilities, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/InAppPurchaseAvailabilityCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchaseAvailabilityCreateRequest.swift
@@ -44,7 +44,7 @@ public struct InAppPurchaseAvailabilityCreateRequest: Codable, Equatable {
                         case inAppPurchases
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .inAppPurchases, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -66,7 +66,7 @@ public struct InAppPurchaseAvailabilityCreateRequest: Codable, Equatable {
                         case territories
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .territories, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -83,7 +83,7 @@ public struct InAppPurchaseAvailabilityCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .inAppPurchaseAvailabilities, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/InAppPurchaseContent.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchaseContent.swift
@@ -60,7 +60,7 @@ public struct InAppPurchaseContent: Codable, Equatable, Identifiable {
                     case inAppPurchases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -77,7 +77,7 @@ public struct InAppPurchaseContent: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .inAppPurchaseContents, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/InAppPurchaseLocalization.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchaseLocalization.swift
@@ -67,7 +67,7 @@ public struct InAppPurchaseLocalization: Codable, Equatable, Identifiable {
                     case inAppPurchases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -84,7 +84,7 @@ public struct InAppPurchaseLocalization: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .inAppPurchaseLocalizations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/InAppPurchaseLocalizationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchaseLocalizationCreateRequest.swift
@@ -43,7 +43,7 @@ public struct InAppPurchaseLocalizationCreateRequest: Codable, Equatable {
                         case inAppPurchases
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .inAppPurchases, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -59,7 +59,7 @@ public struct InAppPurchaseLocalizationCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .inAppPurchaseLocalizations, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/InAppPurchaseLocalizationUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchaseLocalizationUpdateRequest.swift
@@ -27,7 +27,7 @@ public struct InAppPurchaseLocalizationUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .inAppPurchaseLocalizations, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/InAppPurchasePrice.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchasePrice.swift
@@ -65,7 +65,7 @@ public struct InAppPurchasePrice: Codable, Equatable, Identifiable {
                     case inAppPurchasePricePoints
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchasePricePoints, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -104,7 +104,7 @@ public struct InAppPurchasePrice: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -122,7 +122,7 @@ public struct InAppPurchasePrice: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .inAppPurchasePrices, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/InAppPurchasePriceInlineCreate.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchasePriceInlineCreate.swift
@@ -40,7 +40,7 @@ public struct InAppPurchasePriceInlineCreate: Codable, Equatable, Identifiable {
                     case inAppPurchases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -62,7 +62,7 @@ public struct InAppPurchasePriceInlineCreate: Codable, Equatable, Identifiable {
                     case inAppPurchasePricePoints
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchasePricePoints, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -79,7 +79,7 @@ public struct InAppPurchasePriceInlineCreate: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String? = nil, attributes: Attributes? = nil, relationships: Relationships? = nil) {
+    public init(type: `Type` = .inAppPurchasePrices, id: String? = nil, attributes: Attributes? = nil, relationships: Relationships? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/InAppPurchasePricePoint.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchasePricePoint.swift
@@ -58,7 +58,7 @@ public struct InAppPurchasePricePoint: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -75,7 +75,7 @@ public struct InAppPurchasePricePoint: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .inAppPurchasePricePoints, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/InAppPurchasePriceSchedule.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchasePriceSchedule.swift
@@ -48,7 +48,7 @@ public struct InAppPurchasePriceSchedule: Codable, Equatable, Identifiable {
                     case inAppPurchases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -87,7 +87,7 @@ public struct InAppPurchasePriceSchedule: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -127,7 +127,7 @@ public struct InAppPurchasePriceSchedule: Codable, Equatable, Identifiable {
                     case inAppPurchasePrices
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchasePrices, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -168,7 +168,7 @@ public struct InAppPurchasePriceSchedule: Codable, Equatable, Identifiable {
                     case inAppPurchasePrices
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchasePrices, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -189,7 +189,7 @@ public struct InAppPurchasePriceSchedule: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .inAppPurchasePriceSchedules, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/InAppPurchasePriceScheduleCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchasePriceScheduleCreateRequest.swift
@@ -33,7 +33,7 @@ public struct InAppPurchasePriceScheduleCreateRequest: Codable, Equatable {
                         case inAppPurchases
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .inAppPurchases, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -55,7 +55,7 @@ public struct InAppPurchasePriceScheduleCreateRequest: Codable, Equatable {
                         case territories
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .territories, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -77,7 +77,7 @@ public struct InAppPurchasePriceScheduleCreateRequest: Codable, Equatable {
                         case inAppPurchasePrices
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .inAppPurchasePrices, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -95,7 +95,7 @@ public struct InAppPurchasePriceScheduleCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .inAppPurchasePriceSchedules, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/InAppPurchaseSubmission.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchaseSubmission.swift
@@ -45,7 +45,7 @@ public struct InAppPurchaseSubmission: Codable, Equatable, Identifiable {
                     case inAppPurchases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -62,7 +62,7 @@ public struct InAppPurchaseSubmission: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .inAppPurchaseSubmissions, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/InAppPurchaseSubmissionCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchaseSubmissionCreateRequest.swift
@@ -30,7 +30,7 @@ public struct InAppPurchaseSubmissionCreateRequest: Codable, Equatable {
                         case inAppPurchases
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .inAppPurchases, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -46,7 +46,7 @@ public struct InAppPurchaseSubmissionCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .inAppPurchaseSubmissions, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/InAppPurchaseV2.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchaseV2.swift
@@ -83,7 +83,7 @@ public struct InAppPurchaseV2: Codable, Equatable, Identifiable {
                     case inAppPurchaseLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchaseLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -124,7 +124,7 @@ public struct InAppPurchaseV2: Codable, Equatable, Identifiable {
                     case inAppPurchasePricePoints
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchasePricePoints, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -164,7 +164,7 @@ public struct InAppPurchaseV2: Codable, Equatable, Identifiable {
                     case inAppPurchaseContents
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchaseContents, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -203,7 +203,7 @@ public struct InAppPurchaseV2: Codable, Equatable, Identifiable {
                     case inAppPurchaseAppStoreReviewScreenshots
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchaseAppStoreReviewScreenshots, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -242,7 +242,7 @@ public struct InAppPurchaseV2: Codable, Equatable, Identifiable {
                     case promotedPurchases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .promotedPurchases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -281,7 +281,7 @@ public struct InAppPurchaseV2: Codable, Equatable, Identifiable {
                     case inAppPurchasePriceSchedules
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchasePriceSchedules, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -320,7 +320,7 @@ public struct InAppPurchaseV2: Codable, Equatable, Identifiable {
                     case inAppPurchaseAvailabilities
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchaseAvailabilities, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -343,7 +343,7 @@ public struct InAppPurchaseV2: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .inAppPurchases, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/InAppPurchaseV2CreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchaseV2CreateRequest.swift
@@ -55,7 +55,7 @@ public struct InAppPurchaseV2CreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -71,7 +71,7 @@ public struct InAppPurchaseV2CreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .inAppPurchases, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/InAppPurchaseV2UpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/InAppPurchaseV2UpdateRequest.swift
@@ -35,7 +35,7 @@ public struct InAppPurchaseV2UpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .inAppPurchases, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/MarketplaceDomain.swift
+++ b/Sources/_Specification/Generated/Entities/MarketplaceDomain.swift
@@ -27,7 +27,7 @@ public struct MarketplaceDomain: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .marketplaceDomains, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/MarketplaceDomainCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/MarketplaceDomainCreateRequest.swift
@@ -26,7 +26,7 @@ public struct MarketplaceDomainCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes) {
+        public init(type: `Type` = .marketplaceDomains, attributes: Attributes) {
             self.type = type
             self.attributes = attributes
         }

--- a/Sources/_Specification/Generated/Entities/MarketplaceSearchDetail.swift
+++ b/Sources/_Specification/Generated/Entities/MarketplaceSearchDetail.swift
@@ -27,7 +27,7 @@ public struct MarketplaceSearchDetail: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .marketplaceSearchDetails, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/MarketplaceSearchDetailCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/MarketplaceSearchDetailCreateRequest.swift
@@ -43,7 +43,7 @@ public struct MarketplaceSearchDetailCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -59,7 +59,7 @@ public struct MarketplaceSearchDetailCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .marketplaceSearchDetails, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/MarketplaceSearchDetailUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/MarketplaceSearchDetailUpdateRequest.swift
@@ -29,7 +29,7 @@ public struct MarketplaceSearchDetailUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .marketplaceSearchDetails, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/MarketplaceWebhook.swift
+++ b/Sources/_Specification/Generated/Entities/MarketplaceWebhook.swift
@@ -27,7 +27,7 @@ public struct MarketplaceWebhook: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .marketplaceWebhooks, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/MarketplaceWebhookCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/MarketplaceWebhookCreateRequest.swift
@@ -31,7 +31,7 @@ public struct MarketplaceWebhookCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes) {
+        public init(type: `Type` = .marketplaceWebhooks, attributes: Attributes) {
             self.type = type
             self.attributes = attributes
         }

--- a/Sources/_Specification/Generated/Entities/MarketplaceWebhookUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/MarketplaceWebhookUpdateRequest.swift
@@ -32,7 +32,7 @@ public struct MarketplaceWebhookUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .marketplaceWebhooks, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/PerfPowerMetric.swift
+++ b/Sources/_Specification/Generated/Entities/PerfPowerMetric.swift
@@ -41,7 +41,7 @@ public struct PerfPowerMetric: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .perfPowerMetrics, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/PrereleaseVersion.swift
+++ b/Sources/_Specification/Generated/Entities/PrereleaseVersion.swift
@@ -58,7 +58,7 @@ public struct PrereleaseVersion: Codable, Equatable, Identifiable {
                     case builds
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .builds, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -98,7 +98,7 @@ public struct PrereleaseVersion: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -116,7 +116,7 @@ public struct PrereleaseVersion: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .preReleaseVersions, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/Profile.swift
+++ b/Sources/_Specification/Generated/Entities/Profile.swift
@@ -92,7 +92,7 @@ public struct Profile: Codable, Equatable, Identifiable {
                     case bundleIDs = "bundleIds"
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .bundleIDs, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -132,7 +132,7 @@ public struct Profile: Codable, Equatable, Identifiable {
                     case devices
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .devices, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -173,7 +173,7 @@ public struct Profile: Codable, Equatable, Identifiable {
                     case certificates
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .certificates, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -199,7 +199,7 @@ public struct Profile: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .profiles, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/ProfileCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/ProfileCreateRequest.swift
@@ -60,7 +60,7 @@ public struct ProfileCreateRequest: Codable, Equatable {
                         case bundleIDs = "bundleIds"
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .bundleIDs, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -82,7 +82,7 @@ public struct ProfileCreateRequest: Codable, Equatable {
                         case devices
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .devices, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -104,7 +104,7 @@ public struct ProfileCreateRequest: Codable, Equatable {
                         case certificates
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .certificates, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -128,7 +128,7 @@ public struct ProfileCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .profiles, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/PromotedPurchase.swift
+++ b/Sources/_Specification/Generated/Entities/PromotedPurchase.swift
@@ -73,7 +73,7 @@ public struct PromotedPurchase: Codable, Equatable, Identifiable {
                     case inAppPurchases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .inAppPurchases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -112,7 +112,7 @@ public struct PromotedPurchase: Codable, Equatable, Identifiable {
                     case subscriptions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -152,7 +152,7 @@ public struct PromotedPurchase: Codable, Equatable, Identifiable {
                     case promotedPurchaseImages
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .promotedPurchaseImages, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -172,7 +172,7 @@ public struct PromotedPurchase: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .promotedPurchases, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/PromotedPurchaseCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/PromotedPurchaseCreateRequest.swift
@@ -48,7 +48,7 @@ public struct PromotedPurchaseCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -70,7 +70,7 @@ public struct PromotedPurchaseCreateRequest: Codable, Equatable {
                         case inAppPurchases
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .inAppPurchases, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -92,7 +92,7 @@ public struct PromotedPurchaseCreateRequest: Codable, Equatable {
                         case subscriptions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -110,7 +110,7 @@ public struct PromotedPurchaseCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .promotedPurchases, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/PromotedPurchaseImage.swift
+++ b/Sources/_Specification/Generated/Entities/PromotedPurchaseImage.swift
@@ -78,7 +78,7 @@ public struct PromotedPurchaseImage: Codable, Equatable, Identifiable {
                     case promotedPurchases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .promotedPurchases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -95,7 +95,7 @@ public struct PromotedPurchaseImage: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .promotedPurchaseImages, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/PromotedPurchaseImageCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/PromotedPurchaseImageCreateRequest.swift
@@ -41,7 +41,7 @@ public struct PromotedPurchaseImageCreateRequest: Codable, Equatable {
                         case promotedPurchases
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .promotedPurchases, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct PromotedPurchaseImageCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .promotedPurchaseImages, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/PromotedPurchaseImageUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/PromotedPurchaseImageUpdateRequest.swift
@@ -32,7 +32,7 @@ public struct PromotedPurchaseImageUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .promotedPurchaseImages, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/PromotedPurchaseUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/PromotedPurchaseUpdateRequest.swift
@@ -32,7 +32,7 @@ public struct PromotedPurchaseUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .promotedPurchases, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/ReviewSubmission.swift
+++ b/Sources/_Specification/Generated/Entities/ReviewSubmission.swift
@@ -72,7 +72,7 @@ public struct ReviewSubmission: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -112,7 +112,7 @@ public struct ReviewSubmission: Codable, Equatable, Identifiable {
                     case reviewSubmissionItems
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .reviewSubmissionItems, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -152,7 +152,7 @@ public struct ReviewSubmission: Codable, Equatable, Identifiable {
                     case appStoreVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -191,7 +191,7 @@ public struct ReviewSubmission: Codable, Equatable, Identifiable {
                     case actors
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .actors, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -230,7 +230,7 @@ public struct ReviewSubmission: Codable, Equatable, Identifiable {
                     case actors
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .actors, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -251,7 +251,7 @@ public struct ReviewSubmission: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .reviewSubmissions, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/ReviewSubmissionCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/ReviewSubmissionCreateRequest.swift
@@ -39,7 +39,7 @@ public struct ReviewSubmissionCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -55,7 +55,7 @@ public struct ReviewSubmissionCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .reviewSubmissions, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/ReviewSubmissionItem.swift
+++ b/Sources/_Specification/Generated/Entities/ReviewSubmissionItem.swift
@@ -66,7 +66,7 @@ public struct ReviewSubmissionItem: Codable, Equatable, Identifiable {
                     case appStoreVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -105,7 +105,7 @@ public struct ReviewSubmissionItem: Codable, Equatable, Identifiable {
                     case appCustomProductPageVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appCustomProductPageVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -144,7 +144,7 @@ public struct ReviewSubmissionItem: Codable, Equatable, Identifiable {
                     case appStoreVersionExperiments
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionExperiments, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -183,7 +183,7 @@ public struct ReviewSubmissionItem: Codable, Equatable, Identifiable {
                     case appStoreVersionExperiments
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersionExperiments, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -222,7 +222,7 @@ public struct ReviewSubmissionItem: Codable, Equatable, Identifiable {
                     case appEvents
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appEvents, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -243,7 +243,7 @@ public struct ReviewSubmissionItem: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .reviewSubmissionItems, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/ReviewSubmissionItemCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/ReviewSubmissionItemCreateRequest.swift
@@ -35,7 +35,7 @@ public struct ReviewSubmissionItemCreateRequest: Codable, Equatable {
                         case reviewSubmissions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .reviewSubmissions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct ReviewSubmissionItemCreateRequest: Codable, Equatable {
                         case appStoreVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -79,7 +79,7 @@ public struct ReviewSubmissionItemCreateRequest: Codable, Equatable {
                         case appCustomProductPageVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appCustomProductPageVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -101,7 +101,7 @@ public struct ReviewSubmissionItemCreateRequest: Codable, Equatable {
                         case appStoreVersionExperiments
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersionExperiments, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -123,7 +123,7 @@ public struct ReviewSubmissionItemCreateRequest: Codable, Equatable {
                         case appStoreVersionExperiments
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersionExperiments, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -145,7 +145,7 @@ public struct ReviewSubmissionItemCreateRequest: Codable, Equatable {
                         case appEvents
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appEvents, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -166,7 +166,7 @@ public struct ReviewSubmissionItemCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .reviewSubmissionItems, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/ReviewSubmissionItemUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/ReviewSubmissionItemUpdateRequest.swift
@@ -32,7 +32,7 @@ public struct ReviewSubmissionItemUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .reviewSubmissionItems, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/ReviewSubmissionUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/ReviewSubmissionUpdateRequest.swift
@@ -32,7 +32,7 @@ public struct ReviewSubmissionUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .reviewSubmissions, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/RoutingAppCoverage.swift
+++ b/Sources/_Specification/Generated/Entities/RoutingAppCoverage.swift
@@ -62,7 +62,7 @@ public struct RoutingAppCoverage: Codable, Equatable, Identifiable {
                     case appStoreVersions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .appStoreVersions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -79,7 +79,7 @@ public struct RoutingAppCoverage: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .routingAppCoverages, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/RoutingAppCoverageCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/RoutingAppCoverageCreateRequest.swift
@@ -41,7 +41,7 @@ public struct RoutingAppCoverageCreateRequest: Codable, Equatable {
                         case appStoreVersions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .appStoreVersions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct RoutingAppCoverageCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .routingAppCoverages, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/RoutingAppCoverageUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/RoutingAppCoverageUpdateRequest.swift
@@ -32,7 +32,7 @@ public struct RoutingAppCoverageUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .routingAppCoverages, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SandboxTesterV2.swift
+++ b/Sources/_Specification/Generated/Entities/SandboxTesterV2.swift
@@ -53,7 +53,7 @@ public struct SandboxTesterV2: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .sandboxTesters, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SandboxTesterV2UpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SandboxTesterV2UpdateRequest.swift
@@ -43,7 +43,7 @@ public struct SandboxTesterV2UpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .sandboxTesters, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SandboxTestersClearPurchaseHistoryRequestV2.swift
+++ b/Sources/_Specification/Generated/Entities/SandboxTestersClearPurchaseHistoryRequestV2.swift
@@ -14,7 +14,7 @@ public struct SandboxTestersClearPurchaseHistoryRequestV2: Codable, Equatable, I
         case sandboxTestersClearPurchaseHistoryRequest
     }
 
-    public init(type: `Type`, id: String, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .sandboxTestersClearPurchaseHistoryRequest, id: String, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.links = links

--- a/Sources/_Specification/Generated/Entities/SandboxTestersClearPurchaseHistoryRequestV2CreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SandboxTestersClearPurchaseHistoryRequestV2CreateRequest.swift
@@ -30,7 +30,7 @@ public struct SandboxTestersClearPurchaseHistoryRequestV2CreateRequest: Codable,
                         case sandboxTesters
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .sandboxTesters, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -46,7 +46,7 @@ public struct SandboxTestersClearPurchaseHistoryRequestV2CreateRequest: Codable,
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .sandboxTestersClearPurchaseHistoryRequest, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/ScmGitReference.swift
+++ b/Sources/_Specification/Generated/Entities/ScmGitReference.swift
@@ -60,7 +60,7 @@ public struct ScmGitReference: Codable, Equatable, Identifiable {
                     case scmRepositories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .scmRepositories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -77,7 +77,7 @@ public struct ScmGitReference: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .scmGitReferences, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/ScmProvider.swift
+++ b/Sources/_Specification/Generated/Entities/ScmProvider.swift
@@ -25,7 +25,7 @@ public struct ScmProvider: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .scmProviders, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/ScmPullRequest.swift
+++ b/Sources/_Specification/Generated/Entities/ScmPullRequest.swift
@@ -88,7 +88,7 @@ public struct ScmPullRequest: Codable, Equatable, Identifiable {
                     case scmRepositories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .scmRepositories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -105,7 +105,7 @@ public struct ScmPullRequest: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .scmPullRequests, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/ScmRepository.swift
+++ b/Sources/_Specification/Generated/Entities/ScmRepository.swift
@@ -71,7 +71,7 @@ public struct ScmRepository: Codable, Equatable, Identifiable {
                     case scmProviders
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .scmProviders, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -110,7 +110,7 @@ public struct ScmRepository: Codable, Equatable, Identifiable {
                     case scmGitReferences
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .scmGitReferences, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -128,7 +128,7 @@ public struct ScmRepository: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .scmRepositories, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/Subscription.swift
+++ b/Sources/_Specification/Generated/Entities/Subscription.swift
@@ -107,7 +107,7 @@ public struct Subscription: Codable, Equatable, Identifiable {
                     case subscriptionLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -147,7 +147,7 @@ public struct Subscription: Codable, Equatable, Identifiable {
                     case subscriptionAppStoreReviewScreenshots
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionAppStoreReviewScreenshots, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -186,7 +186,7 @@ public struct Subscription: Codable, Equatable, Identifiable {
                     case subscriptionGroups
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionGroups, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -226,7 +226,7 @@ public struct Subscription: Codable, Equatable, Identifiable {
                     case subscriptionIntroductoryOffers
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionIntroductoryOffers, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -267,7 +267,7 @@ public struct Subscription: Codable, Equatable, Identifiable {
                     case subscriptionPromotionalOffers
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionPromotionalOffers, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -308,7 +308,7 @@ public struct Subscription: Codable, Equatable, Identifiable {
                     case subscriptionOfferCodes
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionOfferCodes, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -349,7 +349,7 @@ public struct Subscription: Codable, Equatable, Identifiable {
                     case subscriptionPrices
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionPrices, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -389,7 +389,7 @@ public struct Subscription: Codable, Equatable, Identifiable {
                     case promotedPurchases
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .promotedPurchases, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -428,7 +428,7 @@ public struct Subscription: Codable, Equatable, Identifiable {
                     case subscriptionAvailabilities
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionAvailabilities, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -453,7 +453,7 @@ public struct Subscription: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptions, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionAppStoreReviewScreenshot.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionAppStoreReviewScreenshot.swift
@@ -68,7 +68,7 @@ public struct SubscriptionAppStoreReviewScreenshot: Codable, Equatable, Identifi
                     case subscriptions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -85,7 +85,7 @@ public struct SubscriptionAppStoreReviewScreenshot: Codable, Equatable, Identifi
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionAppStoreReviewScreenshots, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionAppStoreReviewScreenshotCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionAppStoreReviewScreenshotCreateRequest.swift
@@ -41,7 +41,7 @@ public struct SubscriptionAppStoreReviewScreenshotCreateRequest: Codable, Equata
                         case subscriptions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct SubscriptionAppStoreReviewScreenshotCreateRequest: Codable, Equata
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .subscriptionAppStoreReviewScreenshots, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionAppStoreReviewScreenshotUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionAppStoreReviewScreenshotUpdateRequest.swift
@@ -32,7 +32,7 @@ public struct SubscriptionAppStoreReviewScreenshotUpdateRequest: Codable, Equata
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .subscriptionAppStoreReviewScreenshots, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionAvailability.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionAvailability.swift
@@ -59,7 +59,7 @@ public struct SubscriptionAvailability: Codable, Equatable, Identifiable {
                     case subscriptions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -99,7 +99,7 @@ public struct SubscriptionAvailability: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -118,7 +118,7 @@ public struct SubscriptionAvailability: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionAvailabilities, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionAvailabilityCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionAvailabilityCreateRequest.swift
@@ -44,7 +44,7 @@ public struct SubscriptionAvailabilityCreateRequest: Codable, Equatable {
                         case subscriptions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -66,7 +66,7 @@ public struct SubscriptionAvailabilityCreateRequest: Codable, Equatable {
                         case territories
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .territories, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -83,7 +83,7 @@ public struct SubscriptionAvailabilityCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .subscriptionAvailabilities, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionCreateRequest.swift
@@ -67,7 +67,7 @@ public struct SubscriptionCreateRequest: Codable, Equatable {
                         case subscriptionGroups
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptionGroups, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -83,7 +83,7 @@ public struct SubscriptionCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .subscriptions, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionGracePeriod.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionGracePeriod.swift
@@ -41,7 +41,7 @@ public struct SubscriptionGracePeriod: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionGracePeriods, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionGracePeriodUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionGracePeriodUpdateRequest.swift
@@ -43,10 +43,41 @@ public struct SubscriptionGracePeriodUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public struct Relationships: Codable, Hashable {
+            public var app: App?
+
+            public struct App: Codable, Hashable {
+                public var data: Data?
+
+                public struct Data: Codable, Hashable, Identifiable {
+                    public var type: `Type`
+                    public var id: String
+
+                    public enum `Type`: String, Codable, CaseIterable {
+                        case apps
+                    }
+
+                    public init(type: `Type` = .apps, id: String) {
+                        self.type = type
+                        self.id = id
+                    }
+                }
+
+                public init(data: Data? = nil) {
+                    self.data = data
+                }
+            }
+
+            public init(app: App? = nil) {
+                self.app = app
+            }
+        }
+
+        public init(type: `Type` = .subscriptionGracePeriods, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes
+            self.relationships = relationships
         }
     }
 

--- a/Sources/_Specification/Generated/Entities/SubscriptionGracePeriodUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionGracePeriodUpdateRequest.swift
@@ -43,7 +43,7 @@ public struct SubscriptionGracePeriodUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .subscriptionGracePeriods, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionGracePeriodUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionGracePeriodUpdateRequest.swift
@@ -43,41 +43,10 @@ public struct SubscriptionGracePeriodUpdateRequest: Codable, Equatable {
             }
         }
 
-        public struct Relationships: Codable, Hashable {
-            public var app: App?
-
-            public struct App: Codable, Hashable {
-                public var data: Data?
-
-                public struct Data: Codable, Hashable, Identifiable {
-                    public var type: `Type`
-                    public var id: String
-
-                    public enum `Type`: String, Codable, CaseIterable {
-                        case apps
-                    }
-
-                    public init(type: `Type` = .apps, id: String) {
-                        self.type = type
-                        self.id = id
-                    }
-                }
-
-                public init(data: Data? = nil) {
-                    self.data = data
-                }
-            }
-
-            public init(app: App? = nil) {
-                self.app = app
-            }
-        }
-
-        public init(type: `Type` = .subscriptionGracePeriods, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
+        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes
-            self.relationships = relationships
         }
     }
 

--- a/Sources/_Specification/Generated/Entities/SubscriptionGroup.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionGroup.swift
@@ -56,7 +56,7 @@ public struct SubscriptionGroup: Codable, Equatable, Identifiable {
                     case subscriptions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -97,7 +97,7 @@ public struct SubscriptionGroup: Codable, Equatable, Identifiable {
                     case subscriptionGroupLocalizations
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionGroupLocalizations, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -116,7 +116,7 @@ public struct SubscriptionGroup: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionGroups, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionGroupCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionGroupCreateRequest.swift
@@ -39,7 +39,7 @@ public struct SubscriptionGroupCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -55,7 +55,7 @@ public struct SubscriptionGroupCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .subscriptionGroups, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionGroupLocalization.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionGroupLocalization.swift
@@ -67,7 +67,7 @@ public struct SubscriptionGroupLocalization: Codable, Equatable, Identifiable {
                     case subscriptionGroups
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionGroups, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -84,7 +84,7 @@ public struct SubscriptionGroupLocalization: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionGroupLocalizations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionGroupLocalizationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionGroupLocalizationCreateRequest.swift
@@ -43,7 +43,7 @@ public struct SubscriptionGroupLocalizationCreateRequest: Codable, Equatable {
                         case subscriptionGroups
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptionGroups, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -59,7 +59,7 @@ public struct SubscriptionGroupLocalizationCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .subscriptionGroupLocalizations, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionGroupLocalizationUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionGroupLocalizationUpdateRequest.swift
@@ -27,7 +27,7 @@ public struct SubscriptionGroupLocalizationUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .subscriptionGroupLocalizations, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionGroupSubmission.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionGroupSubmission.swift
@@ -14,7 +14,7 @@ public struct SubscriptionGroupSubmission: Codable, Equatable, Identifiable {
         case subscriptionGroupSubmissions
     }
 
-    public init(type: `Type`, id: String, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionGroupSubmissions, id: String, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.links = links

--- a/Sources/_Specification/Generated/Entities/SubscriptionGroupSubmissionCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionGroupSubmissionCreateRequest.swift
@@ -30,7 +30,7 @@ public struct SubscriptionGroupSubmissionCreateRequest: Codable, Equatable {
                         case subscriptionGroups
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptionGroups, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -46,7 +46,7 @@ public struct SubscriptionGroupSubmissionCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .subscriptionGroupSubmissions, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/SubscriptionGroupUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionGroupUpdateRequest.swift
@@ -25,7 +25,7 @@ public struct SubscriptionGroupUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .subscriptionGroups, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionIntroductoryOffer.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionIntroductoryOffer.swift
@@ -64,7 +64,7 @@ public struct SubscriptionIntroductoryOffer: Codable, Equatable, Identifiable {
                     case subscriptions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -103,7 +103,7 @@ public struct SubscriptionIntroductoryOffer: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -142,7 +142,7 @@ public struct SubscriptionIntroductoryOffer: Codable, Equatable, Identifiable {
                     case subscriptionPricePoints
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionPricePoints, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -161,7 +161,7 @@ public struct SubscriptionIntroductoryOffer: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionIntroductoryOffers, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionIntroductoryOfferCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionIntroductoryOfferCreateRequest.swift
@@ -50,7 +50,7 @@ public struct SubscriptionIntroductoryOfferCreateRequest: Codable, Equatable {
                         case subscriptions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -72,7 +72,7 @@ public struct SubscriptionIntroductoryOfferCreateRequest: Codable, Equatable {
                         case territories
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .territories, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -94,7 +94,7 @@ public struct SubscriptionIntroductoryOfferCreateRequest: Codable, Equatable {
                         case subscriptionPricePoints
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptionPricePoints, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -112,7 +112,7 @@ public struct SubscriptionIntroductoryOfferCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .subscriptionIntroductoryOffers, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionIntroductoryOfferInlineCreate.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionIntroductoryOfferInlineCreate.swift
@@ -47,7 +47,7 @@ public struct SubscriptionIntroductoryOfferInlineCreate: Codable, Equatable, Ide
                     case subscriptions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -69,7 +69,7 @@ public struct SubscriptionIntroductoryOfferInlineCreate: Codable, Equatable, Ide
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -91,7 +91,7 @@ public struct SubscriptionIntroductoryOfferInlineCreate: Codable, Equatable, Ide
                     case subscriptionPricePoints
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionPricePoints, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -109,7 +109,7 @@ public struct SubscriptionIntroductoryOfferInlineCreate: Codable, Equatable, Ide
         }
     }
 
-    public init(type: `Type`, id: String? = nil, attributes: Attributes, relationships: Relationships? = nil) {
+    public init(type: `Type` = .subscriptionIntroductoryOffers, id: String? = nil, attributes: Attributes, relationships: Relationships? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionIntroductoryOfferUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionIntroductoryOfferUpdateRequest.swift
@@ -25,7 +25,7 @@ public struct SubscriptionIntroductoryOfferUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .subscriptionIntroductoryOffers, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionIntroductoryOffersLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionIntroductoryOffersLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct SubscriptionIntroductoryOffersLinkagesRequest: Codable, Equatable 
             case subscriptionIntroductoryOffers
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .subscriptionIntroductoryOffers, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/SubscriptionIntroductoryOffersLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionIntroductoryOffersLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct SubscriptionIntroductoryOffersLinkagesResponse: Codable, Equatable
             case subscriptionIntroductoryOffers
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .subscriptionIntroductoryOffers, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/SubscriptionLocalization.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionLocalization.swift
@@ -67,7 +67,7 @@ public struct SubscriptionLocalization: Codable, Equatable, Identifiable {
                     case subscriptions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -84,7 +84,7 @@ public struct SubscriptionLocalization: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionLocalizations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionLocalizationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionLocalizationCreateRequest.swift
@@ -43,7 +43,7 @@ public struct SubscriptionLocalizationCreateRequest: Codable, Equatable {
                         case subscriptions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -59,7 +59,7 @@ public struct SubscriptionLocalizationCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .subscriptionLocalizations, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionLocalizationUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionLocalizationUpdateRequest.swift
@@ -27,7 +27,7 @@ public struct SubscriptionLocalizationUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .subscriptionLocalizations, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionOfferCode.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionOfferCode.swift
@@ -82,7 +82,7 @@ public struct SubscriptionOfferCode: Codable, Equatable, Identifiable {
                     case subscriptions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -122,7 +122,7 @@ public struct SubscriptionOfferCode: Codable, Equatable, Identifiable {
                     case subscriptionOfferCodeOneTimeUseCodes
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionOfferCodeOneTimeUseCodes, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -163,7 +163,7 @@ public struct SubscriptionOfferCode: Codable, Equatable, Identifiable {
                     case subscriptionOfferCodeCustomCodes
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionOfferCodeCustomCodes, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -204,7 +204,7 @@ public struct SubscriptionOfferCode: Codable, Equatable, Identifiable {
                     case subscriptionOfferCodePrices
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionOfferCodePrices, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -225,7 +225,7 @@ public struct SubscriptionOfferCode: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionOfferCodes, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeCreateRequest.swift
@@ -51,7 +51,7 @@ public struct SubscriptionOfferCodeCreateRequest: Codable, Equatable {
                         case subscriptions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -73,7 +73,7 @@ public struct SubscriptionOfferCodeCreateRequest: Codable, Equatable {
                         case subscriptionOfferCodePrices
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptionOfferCodePrices, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -90,7 +90,7 @@ public struct SubscriptionOfferCodeCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .subscriptionOfferCodes, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeCustomCode.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeCustomCode.swift
@@ -70,7 +70,7 @@ public struct SubscriptionOfferCodeCustomCode: Codable, Equatable, Identifiable 
                     case subscriptionOfferCodes
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionOfferCodes, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -87,7 +87,7 @@ public struct SubscriptionOfferCodeCustomCode: Codable, Equatable, Identifiable 
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionOfferCodeCustomCodes, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeCustomCodeCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeCustomCodeCreateRequest.swift
@@ -43,7 +43,7 @@ public struct SubscriptionOfferCodeCustomCodeCreateRequest: Codable, Equatable {
                         case subscriptionOfferCodes
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptionOfferCodes, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -59,7 +59,7 @@ public struct SubscriptionOfferCodeCustomCodeCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .subscriptionOfferCodeCustomCodes, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeCustomCodeUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeCustomCodeUpdateRequest.swift
@@ -29,7 +29,7 @@ public struct SubscriptionOfferCodeCustomCodeUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .subscriptionOfferCodeCustomCodes, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeOneTimeUseCode.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeOneTimeUseCode.swift
@@ -67,7 +67,7 @@ public struct SubscriptionOfferCodeOneTimeUseCode: Codable, Equatable, Identifia
                     case subscriptionOfferCodes
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionOfferCodes, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -84,7 +84,7 @@ public struct SubscriptionOfferCodeOneTimeUseCode: Codable, Equatable, Identifia
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionOfferCodeOneTimeUseCodes, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeOneTimeUseCodeCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeOneTimeUseCodeCreateRequest.swift
@@ -41,7 +41,7 @@ public struct SubscriptionOfferCodeOneTimeUseCodeCreateRequest: Codable, Equatab
                         case subscriptionOfferCodes
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptionOfferCodes, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -57,7 +57,7 @@ public struct SubscriptionOfferCodeOneTimeUseCodeCreateRequest: Codable, Equatab
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .subscriptionOfferCodeOneTimeUseCodes, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeOneTimeUseCodeUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeOneTimeUseCodeUpdateRequest.swift
@@ -29,7 +29,7 @@ public struct SubscriptionOfferCodeOneTimeUseCodeUpdateRequest: Codable, Equatab
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .subscriptionOfferCodeOneTimeUseCodes, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeOneTimeUseCodeValue.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeOneTimeUseCodeValue.swift
@@ -14,7 +14,7 @@ public struct SubscriptionOfferCodeOneTimeUseCodeValue: Codable, Equatable, Iden
         case subscriptionOfferCodeOneTimeUseCodeValues
     }
 
-    public init(type: `Type`, id: String, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionOfferCodeOneTimeUseCodeValues, id: String, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.links = links

--- a/Sources/_Specification/Generated/Entities/SubscriptionOfferCodePrice.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionOfferCodePrice.swift
@@ -46,7 +46,7 @@ public struct SubscriptionOfferCodePrice: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -85,7 +85,7 @@ public struct SubscriptionOfferCodePrice: Codable, Equatable, Identifiable {
                     case subscriptionPricePoints
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionPricePoints, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -103,7 +103,7 @@ public struct SubscriptionOfferCodePrice: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionOfferCodePrices, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionOfferCodePriceInlineCreate.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionOfferCodePriceInlineCreate.swift
@@ -29,7 +29,7 @@ public struct SubscriptionOfferCodePriceInlineCreate: Codable, Equatable, Identi
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -51,7 +51,7 @@ public struct SubscriptionOfferCodePriceInlineCreate: Codable, Equatable, Identi
                     case subscriptionPricePoints
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionPricePoints, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -68,7 +68,7 @@ public struct SubscriptionOfferCodePriceInlineCreate: Codable, Equatable, Identi
         }
     }
 
-    public init(type: `Type`, id: String? = nil, relationships: Relationships? = nil) {
+    public init(type: `Type` = .subscriptionOfferCodePrices, id: String? = nil, relationships: Relationships? = nil) {
         self.type = type
         self.id = id
         self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionOfferCodeUpdateRequest.swift
@@ -29,7 +29,7 @@ public struct SubscriptionOfferCodeUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .subscriptionOfferCodes, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionPrice.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionPrice.swift
@@ -62,7 +62,7 @@ public struct SubscriptionPrice: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -101,7 +101,7 @@ public struct SubscriptionPrice: Codable, Equatable, Identifiable {
                     case subscriptionPricePoints
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionPricePoints, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -119,7 +119,7 @@ public struct SubscriptionPrice: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionPrices, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionPriceCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionPriceCreateRequest.swift
@@ -48,7 +48,7 @@ public struct SubscriptionPriceCreateRequest: Codable, Equatable {
                         case subscriptions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -70,7 +70,7 @@ public struct SubscriptionPriceCreateRequest: Codable, Equatable {
                         case territories
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .territories, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -92,7 +92,7 @@ public struct SubscriptionPriceCreateRequest: Codable, Equatable {
                         case subscriptionPricePoints
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptionPricePoints, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -110,7 +110,7 @@ public struct SubscriptionPriceCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes? = nil, relationships: Relationships) {
+        public init(type: `Type` = .subscriptionPrices, attributes: Attributes? = nil, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionPriceInlineCreate.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionPriceInlineCreate.swift
@@ -46,7 +46,7 @@ public struct SubscriptionPriceInlineCreate: Codable, Equatable, Identifiable {
                     case subscriptions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -68,7 +68,7 @@ public struct SubscriptionPriceInlineCreate: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -90,7 +90,7 @@ public struct SubscriptionPriceInlineCreate: Codable, Equatable, Identifiable {
                     case subscriptionPricePoints
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionPricePoints, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -108,7 +108,7 @@ public struct SubscriptionPriceInlineCreate: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String? = nil, attributes: Attributes? = nil, relationships: Relationships? = nil) {
+    public init(type: `Type` = .subscriptionPrices, id: String? = nil, attributes: Attributes? = nil, relationships: Relationships? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionPricePoint.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionPricePoint.swift
@@ -58,7 +58,7 @@ public struct SubscriptionPricePoint: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -75,7 +75,7 @@ public struct SubscriptionPricePoint: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionPricePoints, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionPricePointInlineCreate.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionPricePointInlineCreate.swift
@@ -13,7 +13,7 @@ public struct SubscriptionPricePointInlineCreate: Codable, Equatable, Identifiab
         case subscriptionPricePoints
     }
 
-    public init(type: `Type`, id: String? = nil) {
+    public init(type: `Type` = .subscriptionPricePoints, id: String? = nil) {
         self.type = type
         self.id = id
     }

--- a/Sources/_Specification/Generated/Entities/SubscriptionPricesLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionPricesLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct SubscriptionPricesLinkagesRequest: Codable, Equatable {
             case subscriptionPrices
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .subscriptionPrices, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/SubscriptionPricesLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionPricesLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct SubscriptionPricesLinkagesResponse: Codable, Equatable {
             case subscriptionPrices
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .subscriptionPrices, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/SubscriptionPromotionalOffer.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionPromotionalOffer.swift
@@ -63,7 +63,7 @@ public struct SubscriptionPromotionalOffer: Codable, Equatable, Identifiable {
                     case subscriptions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -103,7 +103,7 @@ public struct SubscriptionPromotionalOffer: Codable, Equatable, Identifiable {
                     case subscriptionPromotionalOfferPrices
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionPromotionalOfferPrices, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -122,7 +122,7 @@ public struct SubscriptionPromotionalOffer: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionPromotionalOffers, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionPromotionalOfferCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionPromotionalOfferCreateRequest.swift
@@ -49,7 +49,7 @@ public struct SubscriptionPromotionalOfferCreateRequest: Codable, Equatable {
                         case subscriptions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -71,7 +71,7 @@ public struct SubscriptionPromotionalOfferCreateRequest: Codable, Equatable {
                         case subscriptionPromotionalOfferPrices
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptionPromotionalOfferPrices, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -88,7 +88,7 @@ public struct SubscriptionPromotionalOfferCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships) {
+        public init(type: `Type` = .subscriptionPromotionalOffers, attributes: Attributes, relationships: Relationships) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionPromotionalOfferInlineCreate.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionPromotionalOfferInlineCreate.swift
@@ -46,7 +46,7 @@ public struct SubscriptionPromotionalOfferInlineCreate: Codable, Equatable, Iden
                     case subscriptions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -68,7 +68,7 @@ public struct SubscriptionPromotionalOfferInlineCreate: Codable, Equatable, Iden
                     case subscriptionPromotionalOfferPrices
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionPromotionalOfferPrices, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -85,7 +85,7 @@ public struct SubscriptionPromotionalOfferInlineCreate: Codable, Equatable, Iden
         }
     }
 
-    public init(type: `Type`, id: String? = nil, attributes: Attributes, relationships: Relationships? = nil) {
+    public init(type: `Type` = .subscriptionPromotionalOffers, id: String? = nil, attributes: Attributes, relationships: Relationships? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/SubscriptionPromotionalOfferPrice.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionPromotionalOfferPrice.swift
@@ -46,7 +46,7 @@ public struct SubscriptionPromotionalOfferPrice: Codable, Equatable, Identifiabl
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -85,7 +85,7 @@ public struct SubscriptionPromotionalOfferPrice: Codable, Equatable, Identifiabl
                     case subscriptionPricePoints
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionPricePoints, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -103,7 +103,7 @@ public struct SubscriptionPromotionalOfferPrice: Codable, Equatable, Identifiabl
         }
     }
 
-    public init(type: `Type`, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionPromotionalOfferPrices, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionPromotionalOfferPriceInlineCreate.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionPromotionalOfferPriceInlineCreate.swift
@@ -29,7 +29,7 @@ public struct SubscriptionPromotionalOfferPriceInlineCreate: Codable, Equatable,
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -51,7 +51,7 @@ public struct SubscriptionPromotionalOfferPriceInlineCreate: Codable, Equatable,
                     case subscriptionPricePoints
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptionPricePoints, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -68,7 +68,7 @@ public struct SubscriptionPromotionalOfferPriceInlineCreate: Codable, Equatable,
         }
     }
 
-    public init(type: `Type`, id: String? = nil, relationships: Relationships? = nil) {
+    public init(type: `Type` = .subscriptionPromotionalOfferPrices, id: String? = nil, relationships: Relationships? = nil) {
         self.type = type
         self.id = id
         self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionPromotionalOfferUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionPromotionalOfferUpdateRequest.swift
@@ -32,7 +32,7 @@ public struct SubscriptionPromotionalOfferUpdateRequest: Codable, Equatable {
                         case subscriptionPromotionalOfferPrices
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptionPromotionalOfferPrices, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -48,7 +48,7 @@ public struct SubscriptionPromotionalOfferUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, relationships: Relationships? = nil) {
+        public init(type: `Type` = .subscriptionPromotionalOffers, id: String, relationships: Relationships? = nil) {
             self.type = type
             self.id = id
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionSubmission.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionSubmission.swift
@@ -45,7 +45,7 @@ public struct SubscriptionSubmission: Codable, Equatable, Identifiable {
                     case subscriptions
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .subscriptions, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -62,7 +62,7 @@ public struct SubscriptionSubmission: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .subscriptionSubmissions, id: String, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/SubscriptionSubmissionCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionSubmissionCreateRequest.swift
@@ -30,7 +30,7 @@ public struct SubscriptionSubmissionCreateRequest: Codable, Equatable {
                         case subscriptions
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptions, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -46,7 +46,7 @@ public struct SubscriptionSubmissionCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, relationships: Relationships) {
+        public init(type: `Type` = .subscriptionSubmissions, relationships: Relationships) {
             self.type = type
             self.relationships = relationships
         }

--- a/Sources/_Specification/Generated/Entities/SubscriptionUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/SubscriptionUpdateRequest.swift
@@ -68,7 +68,7 @@ public struct SubscriptionUpdateRequest: Codable, Equatable {
                         case subscriptionIntroductoryOffers
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptionIntroductoryOffers, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -90,7 +90,7 @@ public struct SubscriptionUpdateRequest: Codable, Equatable {
                         case subscriptionPromotionalOffers
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptionPromotionalOffers, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -112,7 +112,7 @@ public struct SubscriptionUpdateRequest: Codable, Equatable {
                         case subscriptionPrices
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .subscriptionPrices, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -130,7 +130,7 @@ public struct SubscriptionUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
+        public init(type: `Type` = .subscriptions, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/Territory.swift
+++ b/Sources/_Specification/Generated/Entities/Territory.swift
@@ -23,7 +23,7 @@ public struct Territory: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .territories, id: String, attributes: Attributes? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/TerritoryAvailability.swift
+++ b/Sources/_Specification/Generated/Entities/TerritoryAvailability.swift
@@ -106,7 +106,7 @@ public struct TerritoryAvailability: Codable, Equatable, Identifiable {
                     case territories
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .territories, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -123,7 +123,7 @@ public struct TerritoryAvailability: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .territoryAvailabilities, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/TerritoryAvailabilityInlineCreate.swift
+++ b/Sources/_Specification/Generated/Entities/TerritoryAvailabilityInlineCreate.swift
@@ -13,7 +13,7 @@ public struct TerritoryAvailabilityInlineCreate: Codable, Equatable, Identifiabl
         case territoryAvailabilities
     }
 
-    public init(type: `Type`, id: String? = nil) {
+    public init(type: `Type` = .territoryAvailabilities, id: String? = nil) {
         self.type = type
         self.id = id
     }

--- a/Sources/_Specification/Generated/Entities/TerritoryAvailabilityUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/TerritoryAvailabilityUpdateRequest.swift
@@ -35,7 +35,7 @@ public struct TerritoryAvailabilityUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil) {
+        public init(type: `Type` = .territoryAvailabilities, id: String, attributes: Attributes? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/TerritoryInlineCreate.swift
+++ b/Sources/_Specification/Generated/Entities/TerritoryInlineCreate.swift
@@ -13,7 +13,7 @@ public struct TerritoryInlineCreate: Codable, Equatable, Identifiable {
         case territories
     }
 
-    public init(type: `Type`, id: String? = nil) {
+    public init(type: `Type` = .territories, id: String? = nil) {
         self.type = type
         self.id = id
     }

--- a/Sources/_Specification/Generated/Entities/User.swift
+++ b/Sources/_Specification/Generated/Entities/User.swift
@@ -74,7 +74,7 @@ public struct User: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -92,7 +92,7 @@ public struct User: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .users, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/UserInvitation.swift
+++ b/Sources/_Specification/Generated/Entities/UserInvitation.swift
@@ -77,7 +77,7 @@ public struct UserInvitation: Codable, Equatable, Identifiable {
                     case apps
                 }
 
-                public init(type: `Type`, id: String) {
+                public init(type: `Type` = .apps, id: String) {
                     self.type = type
                     self.id = id
                 }
@@ -95,7 +95,7 @@ public struct UserInvitation: Codable, Equatable, Identifiable {
         }
     }
 
-    public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
+    public init(type: `Type` = .userInvitations, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil, links: ResourceLinks? = nil) {
         self.type = type
         self.id = id
         self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/UserInvitationCreateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/UserInvitationCreateRequest.swift
@@ -58,7 +58,7 @@ public struct UserInvitationCreateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -74,7 +74,7 @@ public struct UserInvitationCreateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, attributes: Attributes, relationships: Relationships? = nil) {
+        public init(type: `Type` = .userInvitations, attributes: Attributes, relationships: Relationships? = nil) {
             self.type = type
             self.attributes = attributes
             self.relationships = relationships

--- a/Sources/_Specification/Generated/Entities/UserUpdateRequest.swift
+++ b/Sources/_Specification/Generated/Entities/UserUpdateRequest.swift
@@ -50,7 +50,7 @@ public struct UserUpdateRequest: Codable, Equatable {
                         case apps
                     }
 
-                    public init(type: `Type`, id: String) {
+                    public init(type: `Type` = .apps, id: String) {
                         self.type = type
                         self.id = id
                     }
@@ -66,7 +66,7 @@ public struct UserUpdateRequest: Codable, Equatable {
             }
         }
 
-        public init(type: `Type`, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
+        public init(type: `Type` = .users, id: String, attributes: Attributes? = nil, relationships: Relationships? = nil) {
             self.type = type
             self.id = id
             self.attributes = attributes

--- a/Sources/_Specification/Generated/Entities/UserVisibleAppsLinkagesRequest.swift
+++ b/Sources/_Specification/Generated/Entities/UserVisibleAppsLinkagesRequest.swift
@@ -16,7 +16,7 @@ public struct UserVisibleAppsLinkagesRequest: Codable, Equatable {
             case apps
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .apps, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Generated/Entities/UserVisibleAppsLinkagesResponse.swift
+++ b/Sources/_Specification/Generated/Entities/UserVisibleAppsLinkagesResponse.swift
@@ -18,7 +18,7 @@ public struct UserVisibleAppsLinkagesResponse: Codable, Equatable {
             case apps
         }
 
-        public init(type: `Type`, id: String) {
+        public init(type: `Type` = .apps, id: String) {
             self.type = type
             self.id = id
         }

--- a/Sources/_Specification/Request.swift
+++ b/Sources/_Specification/Request.swift
@@ -8,12 +8,12 @@ private let appStoreConnectBaseURL = URL(string: "https://api.appstoreconnect.ap
 
 /// A request model used to describe a resource's attributes.
 public struct Request<Response> {
-    /// HTTP method.
-    public var method: String
-    /// Base URL that the request should be based on.
-    public var baseURL: URL = appStoreConnectBaseURL
     /// Path to the resource.
     public var path: String
+    /// Base URL that the request should be based on.
+    public var baseURL: URL = appStoreConnectBaseURL
+    /// HTTP method.
+    public var method: String
     /// Query string encoded parameters.
     public var query: [(String, String?)]?
     /// Body of the request.
@@ -29,24 +29,24 @@ public struct Request<Response> {
     ///
     /// - Parameters:
     ///   - path: Path to the resource.
-    ///   - method: HTTP method.
     ///   - baseURL: Base URL of the resource. A nil value will result in a default of `"https://api.appstoreconnect.apple.com"`.
+    ///   - method: HTTP method.
     ///   - query: Query string encoded parameters.
     ///   - body: Body of the request.
     ///   - headers: Request headers.
     ///   - id: Operation ID. Unused.
     public init(
         path: String,
-        method: String,
         baseURL: URL? = nil,
+        method: String,
         query: [(String, String?)]? = nil,
         body: (any Encodable)? = nil,
         headers: [String: String]? = nil,
         id: String? = nil
     ) {
         self.path = path
-        self.method = method
         self.baseURL = baseURL ?? appStoreConnectBaseURL
+        self.method = method
         self.query = query
         self.body = body
         self.headers = headers


### PR DESCRIPTION
This PR uses an experimental version of CreateAPI based on CreateAPI/CreateAPI#170 that enhances support around default values. Notably, the App Store Connect API schema doesn't use defaults at all, but there are several cases across the API where a required property is given a variant type with exactly one variant (such as type IDs). In this situation, there is an implied default value that can be provided, which subtly cleans up the call site in common situations. 

For example, here is a code snippet before this PR:

```swift
_ = try await client.send(
    Resources.v1.betaTesterInvitations.post(
        .init(
            data: .init(
                type: .betaTesterInvitations,
                relationships: .init(
                    betaTester: .init(
                        data: .init(
                            type: .betaTesters,
                            id: tester.id
                        )
                    ),
                    app: .init(
                        data: .init(
                            type: .apps,
                            id: app.id
                        )
                    )
                )
            )
        )
    )
)
```

And here it is after the change:

```swift
_ = try await client.send(
    Resources.v1.betaTesterInvitations.post(
        .init(
            data: .init(
                relationships: .init(
                    betaTester: .init(data: .init(id: tester.id)),
                    app: .init(data: .init(id: app.id))
                )
            )
        )
    )
)
```