### PR TITLE
Fix tests and a crash under linux and swift 6

### DIFF
--- a/Sources/AppStoreConnect/Networking/Transport.swift
+++ b/Sources/AppStoreConnect/Networking/Transport.swift
@@ -48,9 +48,9 @@ extension URLSession: Transport {
     public func send(request: URLRequest, decoder: JSONDecoder) async throws -> Response<Data> {
         // These depend on swift-corelibs-foundation, which have not implemented the
         // Task-based API for URLSession.
-        #if (os(Linux) || os(Windows)) && swift(<6.0)
+        #if (os(Linux) || os(Windows))
             return try await withCheckedThrowingContinuation { continuation in
-                send(request: request, decoder: decoder, completion: continuation.resume)
+                send(request: request, decoder: decoder) { result in continuation.resume(with: result) }
             }
         #else
             let (data, urlResponse) = try await data(for: request)
@@ -120,9 +120,9 @@ extension URLSession: Transport {
     public func download(request: URLRequest) async throws -> Response<URL> {
         // These depend on swift-corelibs-foundation, which have not implemented the
         // Task-based API for URLSession.
-        #if (os(Linux) || os(Windows)) && swift(<6.0)
+        #if (os(Linux) || os(Windows))
             return try await withCheckedThrowingContinuation { continuation in
-                download(request: request, completion: continuation.resume)
+                download(request: request) { result in continuation.resume(with: result) }
             }
         #else
             let (fileURL, urlResponse) = try await download(for: request)
@@ -191,9 +191,9 @@ extension URLSession: Transport {
     public func upload(request: URLRequest, data: Data, decoder: JSONDecoder) async throws -> Response<Data> {
         // These depend on swift-corelibs-foundation, which have not implemented the
         // Task-based API for URLSession.
-        #if (os(Linux) || os(Windows)) && swift(<6.0)
+        #if (os(Linux) || os(Windows))
             return try await withCheckedThrowingContinuation { continuation in
-                upload(request: request, data: data, decoder: decoder, completion: continuation.resume)
+                upload(request: request, data: data, decoder: decoder) { result in continuation.resume(with: result) }
             }
         #else
             let (responseData, urlResponse) = try await upload(for: request, from: data)

--- a/Tests/AppStoreConnectTests/AppStoreConnectClientTests.swift
+++ b/Tests/AppStoreConnectTests/AppStoreConnectClientTests.swift
@@ -9,7 +9,7 @@ import XCTest
 #endif
 
 final class AppStoreConnectClientTests: XCTestCase {
-    private struct TestData {
+    private struct TestData: Sendable {
         enum Case {
             case success
             case successPaginated

--- a/Tests/AppStoreConnectTests/TransportTests.swift
+++ b/Tests/AppStoreConnectTests/TransportTests.swift
@@ -36,7 +36,7 @@ extension URLRequest {
 }
 
 class TransportTests: XCTestCase {
-    private func createSession() -> URLSession {
+    private static func createSession() -> URLSession {
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [MockURLProtocol.self]
 
@@ -88,7 +88,7 @@ class TransportTests: XCTestCase {
     func testURLSessionSendRequest() async throws {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .custom(decodeISO8601Date(with:))
-        _ = try await createSession()
+        _ = try await Self.createSession()
             .send(request: .testSendAsync, decoder: decoder)
     }
 
@@ -96,7 +96,7 @@ class TransportTests: XCTestCase {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .custom(decodeISO8601Date(with:))
         try await XCTAssertThrowsError(
-            await createSession()
+            await Self.createSession()
                 .send(request: .testSendAsyncError, decoder: decoder)
         )
     }
@@ -105,7 +105,7 @@ class TransportTests: XCTestCase {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .custom(decodeISO8601Date(with:))
         let expectation = XCTestExpectation(description: "test-send-closure")
-        createSession()
+        Self.createSession()
             .send(request: .testSendClosure, decoder: decoder) { result in
                 XCTAssertNoThrow({ try result.get() })
                 expectation.fulfill()
@@ -116,26 +116,26 @@ class TransportTests: XCTestCase {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .custom(decodeISO8601Date(with:))
         let expectation = XCTestExpectation(description: "test-send-closure-error")
-        createSession()
+        Self.createSession()
             .send(request: .testSendClosureError, decoder: decoder) { result in
                 expectation.fulfill()
             }
     }
 
     func testURLSessionDownloadRequest() async throws {
-        _ = try await createSession()
+        _ = try await Self.createSession()
             .download(request: .testDownloadAsync)
     }
 
     func testURLSessionDownloadRequestFailure() async throws {
         try await XCTAssertThrowsError(
-            await createSession().download(request: .testDownloadAsyncError)
+            await Self.createSession().download(request: .testDownloadAsyncError)
         )
     }
 
     func testURLSessionDownloadRequestCompletion() {
         let expectation = XCTestExpectation(description: "test-download-closure")
-        createSession()
+        Self.createSession()
             .download(request: .testDownloadClosure) { result in
                 XCTAssertNoThrow({ try result.get() })
                 expectation.fulfill()
@@ -144,7 +144,7 @@ class TransportTests: XCTestCase {
 
     func testURLSessionDownloadRequestCompletionFailure() {
         let expectation = XCTestExpectation(description: "test-download-closure-error")
-        createSession()
+        Self.createSession()
             .download(request: .testDownloadClosureError) { result in
                 expectation.fulfill()
             }
@@ -153,7 +153,7 @@ class TransportTests: XCTestCase {
     func testURLSessionUploadRequest() async throws {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .custom(decodeISO8601Date(with:))
-        _ = try await createSession()
+        _ = try await Self.createSession()
             .upload(request: .testUploadAsync, data: Data(), decoder: decoder)
     }
 
@@ -161,7 +161,7 @@ class TransportTests: XCTestCase {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .custom(decodeISO8601Date(with:))
         try await XCTAssertThrowsError(
-            await createSession()
+            await Self.createSession()
                 .upload(request: .testUploadAsyncError, data: Data(), decoder: decoder)
         )
     }
@@ -170,7 +170,7 @@ class TransportTests: XCTestCase {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .custom(decodeISO8601Date(with:))
         let expectation = XCTestExpectation(description: "test-upload-closure")
-        createSession()
+        Self.createSession()
             .upload(request: .testUploadClosure, data: Data(), decoder: decoder) { result in
                 XCTAssertNoThrow({ try result.get() })
                 expectation.fulfill()
@@ -181,7 +181,7 @@ class TransportTests: XCTestCase {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .custom(decodeISO8601Date(with:))
         let expectation = XCTestExpectation(description: "test-upload-closure-error")
-        createSession()
+        Self.createSession()
             .upload(request: .testUploadClosureError, data: Data(), decoder: decoder) { result in
                 expectation.fulfill()
             }

--- a/Tests/Mocks/MockData.swift
+++ b/Tests/Mocks/MockData.swift
@@ -6,7 +6,7 @@ import Foundation
     import FoundationNetworking
 #endif
 
-public struct MockResources {
+public struct MockResources: Sendable {
     public struct Content: Codable, Equatable, Sendable {
         public var name: String
         public var age: Int

--- a/Tests/Mocks/XCTAsserts.swift
+++ b/Tests/Mocks/XCTAsserts.swift
@@ -7,11 +7,11 @@ import XCTest
 
 // swift-format-ignore: AlwaysUseLowerCamelCase
 public func XCTAssertThrowsError<T>(
-    _ expression: @autoclosure () async throws -> T,
+    _ expression: @autoclosure @Sendable () async throws -> T,
     _ message: @autoclosure () -> String = "",
     file: StaticString = #filePath,
     line: UInt = #line,
-    _ errorHandler: (_ error: any Error) -> Void = { _ in }
+    _ errorHandler: @Sendable (_ error: any Error) -> Void = { _ in }
 ) async {
     do {
         _ = try await expression()


### PR DESCRIPTION
- Move back `withCheckedThrowingContinuation` on linux (for all swift versions)
- Clean up some testing helpers