### PR TITLE
Fix upload

### DIFF
--- a/Sources/AppStoreAPI/UploadOperations.swift
+++ b/Sources/AppStoreAPI/UploadOperations.swift
@@ -24,11 +24,7 @@ extension AppStoreConnectClient {
         }
 
         let dataChunk = data[offset..<(length + offset)]
-        let urlRequest = try URLRequest(
-            uploadOperation: operation,
-            encoder: encoder,
-            authenticator: &authenticator
-        )
+        let urlRequest = try URLRequest(uploadOperation: operation, encoder: encoder)
 
         _ = try await retry(with: strategy) {
             try await transport.upload(request: urlRequest, data: dataChunk, decoder: decoder)
@@ -45,11 +41,7 @@ extension UploadOperation {
 }
 
 extension URLRequest {
-    init(
-        uploadOperation: UploadOperation,
-        encoder: JSONEncoder,
-        authenticator: inout any Authenticator
-    ) throws {
+    init(uploadOperation: UploadOperation, encoder: JSONEncoder) throws {
         guard let url = uploadOperation.url.flatMap(URL.init), let method = uploadOperation.method else {
             throw UploadOperation.Error.missingDestination(url: uploadOperation.url, method: uploadOperation.method)
         }
@@ -64,8 +56,7 @@ extension URLRequest {
             method: method,
             headers: headers,
             body: nil,
-            encoder: encoder,
-            authenticator: &authenticator
+            encoder: encoder
         )
     }
 }

--- a/Sources/AppStoreConnect/AppStoreConnectClient.swift
+++ b/Sources/AppStoreConnect/AppStoreConnectClient.swift
@@ -116,7 +116,7 @@ public actor AppStoreConnectClient {
             return nil
         }
 
-        let urlRequest = try URLRequest(url: nextPage, encoder: encoder, authenticator: &authenticator)
+        let urlRequest = try URLRequest(url: nextPage, encoder: encoder, token: authenticator.token())
 
         let response = try await retry(with: strategy) {
             try await transport.send(request: urlRequest, decoder: decoder)

--- a/Sources/AppStoreConnect/Networking/Request.swift
+++ b/Sources/AppStoreConnect/Networking/Request.swift
@@ -24,7 +24,7 @@ extension URLRequest {
             headers: request.headers?.map { ($0.key, $0.value) } ?? [],
             body: request.body,
             encoder: encoder,
-            authenticator: &authenticator
+            token: authenticator.token()
         )
     }
 
@@ -43,7 +43,7 @@ extension URLRequest {
         headers: [(String, String?)] = [],
         body: (any Encodable)? = nil,
         encoder: JSONEncoder,
-        authenticator: inout any Authenticator
+        token: String? = nil
     ) throws {
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = method
@@ -57,8 +57,9 @@ extension URLRequest {
             urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         }
 
-        let token = try authenticator.token()
-        urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        if let token {
+            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
 
         self = urlRequest
     }


### PR DESCRIPTION
I got HTTP 400 Bad Request on screenshot uploads before this change, probably because [upload URLs are unauthenticated](https://developer.apple.com/documentation/appstoreconnectapi/uploading-assets-to-app-store-connect#:~:text=The%20provided%20upload%20URLs%20are%20unauthenticated).